### PR TITLE
add: anti-slop catalog — Claude Design fingerprint table + neutralizer prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Claude Design shipped **April 17, 2026**. Figma closed **−4.26%** the same day
 - [Remix Recipes](#remix-recipes)
 - [Picker: What Should I Use](#picker-what-should-i-use)
 - [Prompts & Cookbooks](#prompts--cookbooks)
-- [Anti-Slop Kit](#anti-slop-kit)
+- [Anti-Slop Kit](#anti-slop-kit) — including [Claude Design's default fingerprints](#claude-designs-default-fingerprints-avoid)
 - [Skills & Plugins](#skills--plugins)
 - [Workflows & Recipes](#workflows--recipes)
 - [Video Teardowns](#video-teardowns)
@@ -119,6 +119,9 @@ Three surfaces:
 - [Product — claude.ai/design](https://claude.ai/design)
 - [Anthropic Labs](https://www.anthropic.com/labs)
 - [Anthropic Prompt Library](https://docs.anthropic.com/en/resources/prompt-library/library) — Brand builder, Website wizard, Prose polisher, 40+ more
+- [`anthropics/skills` — `frontend-design` SKILL.md](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) — the underlying skill Claude Design routes through; auto-loaded by Claude Code for UI work
+- [`anthropics/skills` PR #210](https://github.com/anthropics/skills/pull/210) — clarity revision; 75% win rate across model tiers, biggest lift on Haiku
+- [`anthropics/claude-cookbooks` — frontend aesthetics notebook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb) — Anthropic's own anti-slop primer; quoted in [Anti-Slop Kit](#anti-slop-kit)
 - [Claude Cookbooks — prompting_for_frontend_aesthetics.ipynb](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb)
 - [Prompt engineering overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)
 - [Prompt generator (Console)](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prompt-generator)
@@ -349,6 +352,34 @@ DO use:
 ```
 
 Malewicz's [teardown](https://www.youtube.com/watch?v=IkspcJdeP3U) <img src="https://img.shields.io/youtube/views/IkspcJdeP3U?style=flat-square&label=views&color=191817" height="16"> opens by flagging Claude Design's own logo as "generic, color palette" — exactly the trap this prompt is built to avoid.
+
+### Claude Design's default fingerprints (avoid)
+
+The single biggest community complaint: every Claude Design output looks the same. Catalogued from launch-week Reddit threads, the [Sam Henri Gold blog post](https://samhenri.gold/blog/20260418-claude-design/), the [Banani review](https://www.banani.co/blog/claude-design-review), and [The Neuron Daily round-up](https://www.theneurondaily.com/p/anthropic-s-claude-design-launched-and-reddit-has-thoughts).
+
+| Fingerprint | What it looks like | Counter-rule |
+|---|---|---|
+| **Teal accent everywhere** | The default `#16d5e6`-adjacent action color appears on CTA, headline accent, focus rings, and chart fill | Pick a brand-specific accent in your DESIGN.md before the first generation |
+| **Blinking status dot** | Animated green/lime dot top-right of nav, signals "live"/"AI" by reflex | Reject in your prompt: "no animated status indicators" |
+| **Container soup** | Pills wrapping cards wrapping cards wrapping content; padding stacking 24/24/24 | Cap nesting depth: "containers nest at most 2 levels" |
+| **Default serif headline** | Tiempos- or Source-Serif-adjacent serif paired with sans body — reads like the Anthropic brand's leftovers | Specify font stack with explicit weight + tracking, not a vibe |
+| **Accent bar left of every card** | 4px coloured rule on every card, regardless of semantic meaning | Reserve left-rule for one role (e.g. severity) — never as decoration |
+| **Three-column feature grid in hero** | Almost every landing the model produces has the same section-2 layout | Brief: "no three-column feature grid; choose marquee, alternating-row, or single-column instead" |
+| **Lucide icon stack** | Default icon set across nav, buttons, empty states | Either commit to a single icon family (Phosphor / Heroicons / custom) or ship type-only |
+| **Generative hero in product palette ignored** | Image generator picks colors that "look right" but ignore the DESIGN.md tokens | Constrain the image: "regenerate hero using only `--bg`, `--accent`, `--text`" |
+
+Use the dedicated prompt pack [`prompts/break-default-aesthetic.md`](prompts/break-default-aesthetic.md) to neutralize these in one paste.
+
+### How the defaults got there
+
+Claude Design routes through Anthropic's open-source [`frontend-design` skill](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) — the same skill Claude Code auto-loads for UI work. The skill's defaults bias toward "production-quality first pass" which, in the absence of a DESIGN.md, lands on the same look every time.
+
+Two related Anthropic resources worth bookmarking:
+
+- [**frontend-aesthetics cookbook**](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb) — Anthropic's own anti-slop primer; the source quoted above
+- [**`skills` PR #210**](https://github.com/anthropics/skills/pull/210) — clarity revision of the frontend-design skill; 75% win rate across model tiers, biggest lift on Haiku
+
+Anthropic acknowledges the problem in the cookbook: *"You tend to converge toward generic, 'on distribution' outputs. In frontend design, this creates what users call the 'AI slop' aesthetic. Avoid this: make creative, distinctive frontends that surprise and delight."*
 
 ## Skills & Plugins
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -11,6 +11,7 @@ Drop these into Claude Design or Claude Code. Each pack ships with a real input 
 | [`3-designer-debate`](./3-designer-debate.md) | Three-voice critique + synthesis | <img src="../assets/tags/community.svg" height="16"> |
 | [`remix-two-brands`](./remix-two-brands.md) | Combine two DESIGN.md files coherently | <img src="../assets/tags/remix.svg" height="16"> |
 | [`family-picker`](./family-picker.md) | 3 questions → recommended aesthetic family | <img src="../assets/tags/new.svg" height="16"> |
+| [`break-default-aesthetic`](./break-default-aesthetic.md) | Neutralize Claude Design's teal-default "AI-slop" output | <img src="../assets/tags/anthropic.svg" height="16"> |
 
 ## Submit your own
 

--- a/prompts/break-default-aesthetic.md
+++ b/prompts/break-default-aesthetic.md
@@ -1,0 +1,160 @@
+# `break-default-aesthetic`
+
+One-paste system prompt that neutralizes Claude Design's default "AI-slop" aesthetic — the teal-accent, blinking-status-dot, container-soup look that Reddit identified within hours of launch.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new"> <img src="../assets/tags/anthropic.svg" alt="Anthropic">
+
+---
+
+## When to use
+
+- First message in a new Claude Design project, before any generation
+- Top of any DESIGN.md you hand to Claude Design or Claude Code
+- System prompt for the [Anthropic `frontend-design` skill](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) when you want stricter guardrails
+
+## Input Prompt
+
+```
+Before you generate anything, internalize the following constraints.
+These exist because Claude Design has observable default patterns
+that I do not want in my output.
+
+EXPLICIT REJECTIONS — do not produce any of these unless I ask:
+
+1. ACCENT COLOR
+   - Do not default to teal (#16d5e6 or near). My accent is defined
+     in DESIGN.md and must be the only chromatic action color.
+   - Do not introduce a second accent for variety. One accent only.
+
+2. STATUS INDICATORS
+   - No animated dots, blinking lights, "live" badges, or pulsing
+     orbs in nav, header, or hero.
+   - Status surfaces use static glyphs and explicit text.
+
+3. CONTAINER NESTING
+   - Maximum container depth: 2 (e.g., section > card, not
+     section > card > pill > tag > content).
+   - No card-on-card decoration. If something needs visual separation,
+     use border or tonal shift, not another wrapper.
+
+4. TYPOGRAPHY
+   - No serif headline + sans body unless DESIGN.md specifies it.
+   - No Inter, Roboto, Arial, system-ui, "system stack" fallback as
+     the chosen primary face.
+   - Headline weight, tracking, and optical-size all stated in tokens.
+
+5. LAYOUT CLICHES
+   - No three-column feature grid in hero / section 2.
+   - No identical-aspect card grids when the data is heterogeneous.
+   - No "Get Started" / "Learn More" CTA pair as the default duo.
+
+6. DECORATIVE LEFT RULES
+   - The 4px coloured left-rule on every card is reserved for ONE
+     semantic role (e.g., severity, status). Never decorative.
+
+7. ICON FAMILY
+   - Pick exactly one icon family per project: Phosphor, Heroicons,
+     Tabler, custom. Do not mix.
+   - If no family is provided, prefer type-only solutions over
+     defaulting to Lucide.
+
+8. GENERATIVE IMAGES
+   - Hero illustrations and generative stills must use only colors
+     declared in DESIGN.md (--bg, --surface, --accent, --text).
+   - No purple-pink gradient on dark backgrounds.
+   - No glass / frosted card stack as hero composition.
+
+9. MOTION
+   - Motion serves a purpose: communicate state, hierarchy, or
+     spatial relationship. Decorative motion (floating particles,
+     bobbing icons, scroll-tied parallax) requires explicit request.
+   - Respect prefers-reduced-motion at all times.
+
+10. COPY
+    - Microcopy is product-specific. No "Welcome to {Product}" hero,
+      no "Built for teams" subtitle, no "Get Started" CTA without a
+      verb that names the action.
+
+POSITIVE BIAS — when in doubt, prefer:
+
+- Distinctive type choices that suit the brand voice
+- One bold aesthetic direction over hedged "modern minimal"
+- Border-based depth over drop shadows
+- Editorial rhythm (max-width, vertical breathing) over uniform grids
+- Content-first hero (type, table, demo) over decorative hero
+- Real product surfaces (settings, empty states, edge cases) over
+  marketing hero alone
+
+VERIFICATION — after generating, audit your own output:
+
+- Did I use teal as accent? (FAIL)
+- Is there an animated status dot? (FAIL)
+- Are there 3+ levels of nested containers anywhere? (FAIL)
+- Did I use Inter / Roboto / Arial as primary face? (FAIL)
+- Is there a three-column feature grid in section 2? (FAIL)
+- Are there decorative coloured left-rules on more than one role? (FAIL)
+- Is the hero illustration outside the DESIGN.md palette? (FAIL)
+
+If any FAIL, regenerate the offending region before showing it to me.
+```
+
+## Example Run
+
+**Input:**
+
+```
+{paste the prompt above}
+
+Now build a landing page for our open-source database, "Halite",
+using the attached DESIGN.md (data-dense family, deep navy + amber
+accent, JetBrains Mono headlines).
+```
+
+**Expected behavior:**
+
+- Hero uses amber accent (DESIGN.md), not teal
+- No animated status dot in nav
+- Section 2 is single-column with a code-block demo, not a three-card feature grid
+- Type stack respects JetBrains Mono headlines + the body face declared in DESIGN.md
+- Hero illustration uses navy + amber + the surface tokens; no purple-pink gradient
+- "Get Started" replaced with "Run halite locally" or similar verb-first CTA
+
+**If anti-slop guardrails work, the output should not be confusable with another Claude Design project — even at thumbnail scale.**
+
+## Quality Checks
+
+- [ ] Accent color matches DESIGN.md, not teal
+- [ ] No animated status indicators anywhere
+- [ ] Container nesting ≤ 2 levels
+- [ ] Primary type face is project-specific, not Inter/Roboto/Arial
+- [ ] Section 2 layout is not a three-column feature grid
+- [ ] Coloured left-rules carry semantic role, not decoration
+- [ ] Single icon family throughout
+- [ ] Generative hero uses only DESIGN.md palette
+- [ ] CTA verbs are product-specific
+- [ ] Motion either purposeful or absent
+
+## Variations
+
+- **Strict mode (no AI-slop tolerance):** add "On any FAIL, halt generation and ask me before continuing." Slower, but useful for production handoffs.
+- **Brand-handover mode:** swap "DESIGN.md" references for "the brand kit at {URL}" — works when the system isn't yet a DESIGN.md.
+- **Cookbook-only:** strip sections 1, 2, 6, 8 if your DESIGN.md already covers those rules; keep 3, 4, 5, 7, 9, 10 as universal.
+- **Inverse audit:** paste this *after* generation as a "now audit what you just produced against this rubric and report FAILs" prompt — useful when you didn't seed the project up front.
+
+## Pair with Claude Design
+
+After the first generation, comment inline on any FAIL. Example concrete comments:
+
+- "The hero accent is teal — replace with `--accent` from DESIGN.md."
+- "Remove the green dot in the top nav — DESIGN.md specifies static status surfaces."
+- "Section 2 is the default three-card grid. Redo as a single-column demo with code block."
+
+## References
+
+- Anthropic [`frontend-design` SKILL.md](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) — the underlying skill Claude Design routes through
+- Anthropic [frontend-aesthetics cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb) — original "AI-slop" framing
+- [`anthropics/skills` PR #210](https://github.com/anthropics/skills/pull/210) — 75% win-rate clarity revision
+- [Sam Henri Gold — Thoughts and feelings around Claude Design](https://samhenri.gold/blog/20260418-claude-design/)
+- [The Neuron Daily — Reddit reactions](https://www.theneurondaily.com/p/anthropic-s-claude-design-launched-and-reddit-has-thoughts)
+- [Banani — Claude Design first impressions](https://www.banani.co/blog/claude-design-review)
+- HN: [Thoughts and feelings around Claude Design](https://news.ycombinator.com/item?id=47818700)


### PR DESCRIPTION
## Summary

Largest community complaint about Claude Design (April 2026 launch week): every output looks the same. This PR catalogues the specific defaults and ships a one-paste prompt pack to neutralize them.

## What's new

**README — `Anti-Slop Kit` gains two subsections:**

1. **Claude Design's default fingerprints (avoid)** — 8-row table of observed defaults with counter-rules:
   - Teal accent everywhere
   - Animated status dot in nav
   - Container soup (cards-in-cards-in-pills)
   - Default serif headline + sans body
   - Decorative coloured left-rules on every card
   - Three-column feature grid in section 2
   - Lucide icon stack
   - Generative-image palette drift

2. **How the defaults got there** — links the underlying [`frontend-design` skill](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) and the [frontend-aesthetics cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb), plus PR #210 (75% win rate clarity revision).

**New prompt pack — `prompts/break-default-aesthetic.md`:**

- One-paste system prompt with 10 explicit rejections + 6 positive biases
- Self-verification checklist the agent runs on its own output
- 4 variations: strict mode, brand-handover, cookbook-only, inverse audit
- Concrete pair-with-Claude-Design comments for after the first generation

**Official Resources additions:**

- `anthropics/skills` frontend-design SKILL.md
- `anthropics/skills` PR #210
- `anthropics/claude-cookbooks` frontend-aesthetics notebook

**Indexed in:**

- `prompts/README.md` — new row
- README Contents — new sub-anchor

## Sources catalogued

- [Sam Henri Gold — Stickley joinery angle](https://samhenri.gold/blog/20260418-claude-design/)
- [The Neuron Daily — Reddit reactions](https://www.theneurondaily.com/p/anthropic-s-claude-design-launched-and-reddit-has-thoughts)
- [Banani — first-impressions review](https://www.banani.co/blog/claude-design-review)
- [Quasa.io — token tips](https://quasa.io/media/claude-design-looks-great-but-it-devours-your-token-limits-here-s-how-to-use-it-smartly)
- HN threads: [47806725](https://news.ycombinator.com/item?id=47806725) · [47818700](https://news.ycombinator.com/item?id=47818700) · [47832366](https://news.ycombinator.com/item?id=47832366) · [47845013](https://news.ycombinator.com/item?id=47845013)
- Anthropic [`skills` PR #210](https://github.com/anthropics/skills/pull/210)
- Anthropic [frontend-aesthetics cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/coding/prompting_for_frontend_aesthetics.ipynb)

## Why this PR first

Per the punch list synthesized from `/last30days` research, this is the highest-signal differentiator: the anti-slop angle is unowned by VoltAgent's catalog and addresses the loudest complaint thread of launch week. Token-budget recipe (PR4), DESIGN.md depth (PR5), and remix files (PR6) follow.