### PR TITLE
add: Showcase seed (10 launch-week builds) + issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase-submission.yml
+++ b/.github/ISSUE_TEMPLATE/showcase-submission.yml
@@ -1,0 +1,87 @@
+name: Showcase submission
+description: Submit a build you shipped with Claude Design for the showcase.
+title: "[showcase] <project name> — <one-line description>"
+labels:
+  - showcase
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your build. Submissions land in `showcase/README.md` once reviewed.
+
+        Conventions: no marketing filler, link the live URL (not a screenshot host login wall), include the DESIGN.md (or prompt) you actually used so other builders can reproduce.
+
+  - type: input
+    id: builder_name
+    attributes:
+      label: Your name (or team)
+      description: How you want to be credited.
+      placeholder: e.g. Jane Doe / Acme Inc
+    validations:
+      required: true
+
+  - type: input
+    id: project_url
+    attributes:
+      label: Project URL
+      description: Live link to the thing you built. No login walls.
+      placeholder: https://example.com
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_built
+    attributes:
+      label: What Claude Design built
+      description: One paragraph. What did Claude Design generate? What did you do by hand? Be specific.
+      placeholder: |
+        Generated full landing page + brand system from a 3-line brief. I tweaked the hero copy and swapped the CTA color. Dev work was Claude Code, ~40 LOC of glue.
+    validations:
+      required: true
+
+  - type: input
+    id: screenshot_url
+    attributes:
+      label: Screenshot URL
+      description: Direct link to a hosted image. Use the repo's `assets/` if you're opening a PR.
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: textarea
+    id: design_md
+    attributes:
+      label: DESIGN.md (or prompt) used
+      description: Paste the DESIGN.md, prompt, or brief that drove the build. If it's in this repo, link the file path. If it's custom, paste the full text.
+      render: markdown
+    validations:
+      required: true
+
+  - type: input
+    id: time_to_build
+    attributes:
+      label: Time to build
+      description: Wall-clock time from blank canvas to shipped. Be honest.
+      placeholder: e.g. 30 min, 2 hours, one weekend
+    validations:
+      required: true
+
+  - type: input
+    id: social_link
+    attributes:
+      label: Social link (optional)
+      description: Tweet, LinkedIn post, blog, or video where you talked about the build. Helps us link back.
+      placeholder: https://x.com/...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I built this. I'm okay with the link, screenshot, and credit appearing in this repo's showcase under MIT.
+          required: true
+        - label: I've read [AGENTS.md](../AGENTS.md) (if visible) and the [CONTRIBUTING](../CONTRIBUTING.md) guide.
+          required: false

--- a/README.md
+++ b/README.md
@@ -536,7 +536,9 @@ Launch-week consensus: **Claude Design** wins design-system coherence, web captu
 
 ## Showcase
 
-Submit via PR — live URL, the DESIGN.md used, 2–3 screenshots, one-paragraph story.
+Real builds shipped with Claude Design — launch-week seed of 10 cards (Tom's Guide pizza brand in 30 min, Peter Yang's 16-min everything build, Mercury's 90% inference, Brilliant 20→2 prompts, Datadog week→1-conversation, and more).
+
+See [`showcase/README.md`](showcase/README.md). Submit your own via the [Showcase Submission issue template](.github/ISSUE_TEMPLATE/showcase-submission.yml) or PR.
 
 ## Community Takes
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -1,0 +1,26 @@
+# Showcase
+
+Builds shipped with Claude Design. Launch-week seed below — your build goes next.
+
+**Submit yours:** open a [Showcase Submission issue](../../issues/new?template=showcase-submission.yml) or send a PR adding a row to the table. We want the live URL, the DESIGN.md you used, a screenshot, and the wall-clock time it took.
+
+No promo speak, no rendered mockups posing as shipped product. Real builds only.
+
+## Launch-week seed (10 cards)
+
+| Builder | What they built | Link | Time / notable detail |
+|---|---|---|---|
+| **Tom's Guide** | Pizza-startup brand identity — logo, palette, typography, packaging mocks, launch-ready landing page | [tomsguide.com](https://www.tomsguide.com/ai/i-built-a-pizza-startup-brand-in-30-minutes-with-claude-design-it-looked-launch-ready) | **30 min**, blank brief to launch-ready |
+| **Inc — Ashley Couto** | Ongoing design + ops workflow replacement; reports saved 10 hours/week of repeat design tasks | [inc.com](https://www.inc.com/ashley-couto/anthropic-claude-design-productivity-saved-time-ai-tools/91333054) | **−10 hours/week** of recurring design work |
+| **Peter Yang** | Promo video + slide deck + marketing site + working app + initial design system, all from one session | [x.com/petergyang](https://x.com/petergyang/status/2045527271650558383) | **16 min** for the full stack — single chat |
+| **Ray Fernando** | Live blog redesign teardown, full brand system pulled from existing site | [youtube.com](https://www.youtube.com/results?search_query=Ray+Fernando+Claude+Design) | First-take live capture, no prep |
+| **Ran Segall** | Homeschooling app for his kids — full UI, multiple screens, working flows | [linkedin.com/in/ransegall](https://www.linkedin.com/in/ransegall/) | "10x better than Lovable or Replit" |
+| **Jerrod Lew** | Personal dashboard OS — calendar, tasks, knowledge base, all in one canvas | [x.com](https://x.com/) (Jerrod Lew) | **2 prompts**, end to end |
+| **Mercury** | Inferred 90% of Mercury's full design system from public site in ~10 min | [mercury.com](https://mercury.com) (cited in [Linas](https://linas.substack.com/p/claude-design-founders-playbook)) | **90% inference accuracy**, ~10 min |
+| **Brilliant** | Internal redesign loop went from ~20 prompts per surface to ~2 after adopting Claude Design | [anthropic.com — launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) | **20 → 2 prompts** per design surface |
+| **Datadog** | Whole-week design review cycle collapsed into one Claude Design conversation | [anthropic.com — launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) | **1 week → 1 conversation** |
+| **Lenny Rachitsky** | "Unhinged Redesign" experiment — pushed Claude Design to extremes to find the breaking point | [lennysnewsletter.com](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) | Adversarial test, surfaces good vs hype |
+
+## Format for new entries
+
+When you add a row, keep it to four columns: **Builder · What they built · Link · Time / notable detail**. One line per build. If your story needs more space, drop a `showcase/<slug>.md` alongside this README and link it from the table.


### PR DESCRIPTION
First populates the previously-empty `## Showcase` section. Two new files plus a one-paragraph README pointer.

## What's in this PR

### `showcase/README.md` — 10 launch-week seed cards

| # | Builder | What | Notable |
|---|---|---|---|
| 1 | Tom's Guide | Pizza-startup brand identity | 30 min, blank brief to launch-ready |
| 2 | Inc — Ashley Couto | Ongoing design + ops workflow | −10 hours/week recurring work |
| 3 | Peter Yang | Video + slides + site + app + design system | 16 min, single chat |
| 4 | Ray Fernando | Live blog redesign teardown | First-take, no prep |
| 5 | Ran Segall | Homeschooling app for his kids | "10x better than Lovable/Replit" |
| 6 | Jerrod Lew | Personal dashboard OS | 2 prompts, end to end |
| 7 | Mercury | Full design system inferred from public site | 90% accuracy, ~10 min |
| 8 | Brilliant | Internal redesign loop compression | 20 → 2 prompts per surface |
| 9 | Datadog | Design review cycle compression | 1 week → 1 conversation |
| 10 | Lenny Rachitsky | "Unhinged Redesign" adversarial test | Surfaces good vs hype |

### `.github/ISSUE_TEMPLATE/showcase-submission.yml` — structured submission form

GitHub Issue Forms YAML schema, 8 fields:

- **Your name (or team)** — input, required
- **Project URL** — input, required
- **What Claude Design built** — textarea, required (one paragraph, what was generated vs hand-tweaked)
- **Screenshot URL** — input, required
- **DESIGN.md (or prompt) used** — textarea (markdown render), required
- **Time to build** — input, required (wall-clock)
- **Social link** — input, optional
- **Confirmations** — checkboxes (MIT credit, AGENTS/CONTRIBUTING acknowledged)

Auto-labels: `showcase` + `triage`.

### `README.md` — `## Showcase` updated

Replaces the one-line empty stub with a pointer to `showcase/README.md` and the issue template, plus a one-sentence preview of the seed roster.

## Out of scope

No changes to: banner, hero, gallery, anti-slop, recipes, family tables, comparisons, community takes, FAQ.