### PR TITLE
add: 4 workflow recipes (connectors, repo-to-system, web-capture, pitch-deck)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,12 +441,12 @@ End-to-end flows in `/recipes/<name>.md`.
 
 1. [**Landing page in 20 minutes**](recipes/landing-page-20-min.md) — DESIGN.md → Claude Design → Claude Code → Vercel
 2. [**Figma file → DESIGN.md**](recipes/figma-to-design-md.md) — drag `.fig` in chat, extract tokens, reuse
-3. **Existing repo → design system** — point Claude at your CSS, get canonical DESIGN.md back
+3. [**Existing repo → design system**](recipes/repo-to-design-system.md) — point Claude at your CSS, get canonical DESIGN.md back
 4. [**Wireframe → hi-fi**](recipes/wireframe-to-hifi.md) — low-fi sketch to pixel-perfect comp
-5. **Pitch deck from README** — 12-slide deck from a project README
+5. [**Pitch deck from README**](recipes/pitch-deck-from-readme.md) — 12-slide deck from a project README
 6. [**Brand extraction**](recipes/brand-extraction.md) — URL → DESIGN.md describing a competitor's system
 7. **Design-system governance** — lock tokens as `SKILL.md` for every future project
-8. **Web capture → prototype** — use the native capture tool on your live site
+8. [**Web capture → prototype**](recipes/web-capture-to-prototype.md) — use the native capture tool on your live site
 9. **16-minute everything build** — per @petergyang: video + slides + website + app + initial system
 10. **Two-brand remix** — combine tokens from two DESIGN.md files coherently
 11. **Claude Design → Canva export** — designer collaboration pathway

--- a/recipes/connectors-slack-docs.md
+++ b/recipes/connectors-slack-docs.md
@@ -1,0 +1,127 @@
+# Connectors — Slack, Drive, Docs into Claude Design
+
+Wire your team's actual context into Claude Design so it builds against real meeting notes, decks, and threads — not made-up product copy.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Pull a Slack thread, a Google Doc, or a Drive folder directly into a Claude Design session so the prototype, deck, or design system reflects what your team actually said. Per Ryan Mather (Anthropic): *"Read the notes from yesterday's product roast meeting and create a deck that addresses every concern."*
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Enable connectors | 2 min (one-time) |
+| 2. Pick the source artifact | 2 min |
+| 3. Run the connector-aware prompt | 4 min |
+| 4. Verify Claude pulled the right context | 3 min |
+| 5. Generate + iterate | 8 min |
+| **Total (after one-time setup)** | **~17 min** |
+
+## Inputs
+
+- Pro / Max / Team / Enterprise plan with Claude Design enabled
+- An admin who can authorize connectors at the org level (or your own personal connectors if Free-text linked)
+- A real source: Slack channel, Slack thread URL, Google Doc URL, or Drive folder
+- A target artifact: deck, landing page, prototype screen, or DESIGN.md update
+
+## Steps
+
+### 1. Enable connectors (one-time)
+
+In Claude (claude.ai → Settings → Connectors), authorize:
+
+- **Slack** — gives `slack_search_*`, `slack_read_thread`, `slack_read_channel`
+- **Google Drive** — gives Doc + Sheet + Slide reads, folder listings
+- **GitHub** (optional but useful for repo-derived briefs)
+
+Org admins enable per-workspace. Personal Pro users can authorize their own. If you only see "Web Search" and no connectors, your plan or workspace policy hasn't enabled them yet.
+
+### 2. Pick the source artifact
+
+Three patterns work cleanly. Don't mix them in one prompt — Claude handles a single source much better than a junk drawer.
+
+- **Single Slack thread** — copy the thread permalink from Slack (right-click message → Copy link)
+- **Single Google Doc** — share with your Claude account, copy the URL
+- **Drive folder** — share the folder, give Claude the folder URL; expect it to read the top 5–10 docs by recency
+
+### 3. Run the connector-aware prompt
+
+```
+Read the [Slack thread / Google Doc / Drive folder] at:
+{paste URL}
+
+Summarize the concrete asks in three buckets:
+- Decisions made
+- Open questions
+- Concerns / objections raised by name
+
+Then build a 12-slide deck that:
+- Opens with the problem framed in the team's own language
+- Addresses every concern in the "Concerns" bucket on its own slide
+  with the objector's name in the speaker notes
+- Closes with the decisions made and the open questions as next steps
+
+Use the attached DESIGN.md (`/design-md/<family>/<brand>.md`) as the
+source of truth for color, type, and component style. Quote at least
+three direct phrases from the source so I can verify you actually read it.
+```
+
+Drag your `DESIGN.md` into the chat alongside the connector reference.
+
+### 4. Verify Claude pulled the right context
+
+This is the step most people skip. Connectors silently fail when:
+
+- The artifact is in a workspace you forgot to authorize
+- The doc is shared with "your org" but Claude is auth'd as a different identity
+- The thread is in a private channel Claude wasn't invited to
+
+Sanity check by asking:
+
+```
+Before generating, paste back the three most recent timestamps from the
+Slack thread and the last edit time on the doc. If you can't, stop and
+tell me what failed.
+```
+
+If it hallucinates timestamps, the connector isn't actually wired. Re-auth and retry.
+
+### 5. Generate + iterate
+
+Once the source is confirmed, let it build. Then comment inline on slides where the framing missed nuance ("slide 4 misses Priya's point about onboarding friction — pull her exact quote"). Inline comments on the artifact beat re-prompting from scratch.
+
+## Quality Checks
+
+- [ ] Each "concern" slide names the person who raised it
+- [ ] At least three direct quotes from the source artifact appear verbatim
+- [ ] No invented stats — if the source says "users complained," the deck doesn't claim "47% of users"
+- [ ] DESIGN.md tokens are honored (no rogue accent colors)
+- [ ] Speaker notes cite the source URL on every slide that pulls from it
+- [ ] If Drive folder: list of files actually read appears in the response
+
+## Variations
+
+- **Standup-to-status-page:** point Claude at this week's standup channel, generate a public-facing weekly status page in your DESIGN.md
+- **Customer-call-to-landing-page:** transcript in a Doc + DESIGN.md → landing page that uses customer language verbatim
+- **Roast-meeting-to-redesign-brief:** the Mather example — design critique notes become a prioritized redesign list with mockups
+- **Cross-doc synthesis:** point Claude at a Drive folder of 6 PRDs, ask for a unified roadmap deck
+
+## Common Failures
+
+- **Claude invents quotes.** Cause: connector silent-failed; it generated plausible team-speak instead of reading the source. Fix: always run the verification prompt in Step 4 before generating.
+- **Burns through quota fast.** Cause: connectors pull large context windows on every turn. Fix: bundle the connector read into the *first* prompt; don't re-trigger it on every iteration. Subsequent edits should reference what was already loaded.
+- **"I don't have access to that link."** Cause: the share permission is "anyone in org" but Claude's connector identity isn't in that org. Fix: share directly with the email tied to your Claude account, or re-auth the connector.
+- **Slack thread truncated.** Cause: long threads (>200 messages) get summarized lossily. Fix: ask Claude to read the thread in two passes — first 100 messages, then 100–200 — and merge.
+- **Output mixes two unrelated docs.** Cause: pointed at a folder with mixed content. Fix: move the relevant docs to a fresh folder, or pass URLs one at a time.
+
+## References
+
+- [Ryan Mather — 7 tips for Claude Design](https://x.com/Flomerboy/status/2045162321589252458) — tip #4 (connectors-to-Slack/docs) is the source of this recipe
+- [Claude connectors documentation](https://support.claude.com/en/articles/10167454-using-connectors-with-claude) — official setup
+- [Anthropic Labs — Claude Design overview](https://www.anthropic.com/news/claude-design)
+- [Department of Product — Claude Design is here](https://departmentofproduct.substack.com/p/claude-design-is-here-everything) — connector workflow examples
+- [Linas Beliūnas — Founder's Playbook](https://linas.substack.com/p/claude-design-founders-playbook) — workflow #6 covers Drive + Doc inputs

--- a/recipes/pitch-deck-from-readme.md
+++ b/recipes/pitch-deck-from-readme.md
@@ -1,0 +1,146 @@
+# Pitch Deck from README
+
+Turn a project README into a 12-slide pitch deck in one Claude Design pass. Useful for OSS maintainers pitching internal champions, indie hackers preparing for a sales call, or founders walking a partner through a side project.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Generate a polished, on-brand 12-slide deck from an existing README. The README does the work of structuring the narrative; Claude Design does the work of making it look like you spent a week in Keynote.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Pick + tighten the README | 5 min |
+| 2. Pair it with a DESIGN.md | 1 min |
+| 3. Run the deck prompt | 4 min |
+| 4. Inline-edit slides 1, 6, 12 | 6 min |
+| 5. Export to PDF / PPTX | 2 min |
+| **Total** | **~18 min** |
+
+## Inputs
+
+- A README that already has: a one-line pitch, a problem statement, a "what it does" section, and either install steps or examples
+- A `DESIGN.md` from `/design-md/<family>/` (or your project's own)
+- One audience descriptor: *who is this deck for* (investors / engineering leadership / a specific customer)
+- Optional: a logo SVG
+
+## Steps
+
+### 1. Pick + tighten the README
+
+A great deck-from-README needs a great README. Fast audit before you start:
+
+- **Lede** — does the first paragraph say what this *is* in one sentence? If no, fix it before generating.
+- **Problem** — is there a paragraph that names the pain in user-language (not feature-language)? If no, write one.
+- **Differentiation** — is there a "vs alternatives" line or table? If no, the deck will end up generic.
+- **Proof** — any metrics, GitHub stars, customer names, screenshots? Even one helps.
+
+Don't try to make Claude write a deck from a sparse README. Tighten the README first; the deck will inherit the quality.
+
+### 2. Pair it with a DESIGN.md
+
+The deck's visual system comes from `DESIGN.md`, not from defaults. Pick by audience:
+
+- **VCs / financial audience** → [editorial/vercel.md](../design-md/editorial/vercel.md) or `mercury.md` if shipped
+- **Developer audience** → [terminal/warp.md](../design-md/terminal/warp.md) or [data-dense/posthog.md](../design-md/data-dense/posthog.md)
+- **Creator / consumer audience** → [cinematic/runway.md](../design-md/cinematic/runway.md)
+- **Internal champion / corporate** → editorial family, neutral palette
+
+### 3. Run the deck prompt
+
+```
+Build a 12-slide pitch deck from the attached README.
+
+Audience: { investors / eng leadership / sales prospect / internal champion }
+Goal of the deck: { fund / approve / buy / greenlight }
+
+Use the attached DESIGN.md as the source of truth for color, type,
+layout, and component style. Do not invent new tokens.
+
+Slide structure:
+ 1.  Title — project name + one-line pitch + your name + date
+ 2.  The problem — in the audience's language, not feature-language
+ 3.  Why now — what changed in the world that makes this possible/urgent
+ 4.  Existing solutions and why they fall short — name them by name,
+     1–2 sentences each, no strawmen
+ 5.  Our approach — the core idea in one diagram + one paragraph
+ 6.  How it works — 3-step flow with concrete primitives
+ 7.  Proof — every metric, customer, star count, or quote in the README
+ 8.  Differentiation — feature matrix vs the alternatives in slide 4
+ 9.  Roadmap — next 3 milestones with rough dates
+10.  Team / maintainers — names, faces if available, one line of credibility each
+11.  The ask — what specifically do you want from this audience? (dollars,
+     headcount, intro, pilot)
+12.  Closing — contact + repo link + one memorable line
+
+Tone: confident, specific, no hype words ("revolutionary", "game-changing",
+"seamless"). Numbers wherever the README has them. If the README doesn't
+support a claim, leave the slide thin rather than pad with filler.
+
+Speaker notes on every slide — 2–3 sentences I can read aloud.
+```
+
+Drag both files (README.md + DESIGN.md) into the chat.
+
+### 4. Inline-edit slides 1, 6, 12
+
+These three carry disproportionate weight:
+
+- **Slide 1 (Title)** — the one-line pitch is the whole deck compressed. If it's flat, ask Claude to generate three alternatives and pick.
+- **Slide 6 (How it works)** — diagrams are where Claude Design either ships or whiffs. Comment specifically: "the arrows are too thin, scale them to match body weight" or "this should be a 3-column flow, not a stacked list."
+- **Slide 12 (Closing)** — the memorable line. Often the README's tagline works; sometimes the deck needs its own. Test by reading slide 12 out loud — does it land?
+
+Other slides usually need light tuning only.
+
+### 5. Export
+
+Claude Design exports to:
+
+- **PDF** — best for circulation, looks identical on every machine
+- **PPTX** — best for handoff to a presenter who needs to edit further (sales, IR)
+- **Web link** — best for async review with comments
+
+Pick based on who's downstream. PDF for "send and done"; PPTX for "they'll edit"; link for "they'll comment."
+
+## Quality Checks
+
+- [ ] Slide 1's one-liner is the same one your README opens with (consistency = trust)
+- [ ] Slide 4 names existing solutions by name, no strawmen
+- [ ] Slide 7 contains zero invented metrics — every number traces to the README
+- [ ] Slide 11 has a specific ask, not "let's chat"
+- [ ] Speaker notes on every slide
+- [ ] No hype words: revolutionary / game-changing / seamless / cutting-edge
+- [ ] Single accent color (matches `--accent` in DESIGN.md)
+- [ ] Mono numerals used in any data slide (per DESIGN.md typography rules)
+- [ ] Logo (if provided) appears on slides 1 + 12, nowhere else
+
+## Variations
+
+- **Investor version + customer version from one README:** run the prompt twice with different audience descriptors; keep both, label clearly
+- **Conference-talk variant:** swap "the ask" for "what to take away" — slide 11 becomes 3 takeaways
+- **Deck-as-changelog:** generate from a CHANGELOG instead of README; useful for quarterly reviews
+- **One-pager + deck combined:** ask Claude to also produce a single-page PDF summary alongside; uses same DESIGN.md tokens
+- **Fundraising deep-dive:** add a slide 13 with TAM / SAM / SOM if the audience expects it; most pre-seed decks should *not*
+- **Internal champion deck:** swap slide 8 (differentiation) for "implementation timeline + cost"
+
+## Common Failures
+
+- **The deck is generic despite a great README.** Cause: DESIGN.md was attached but not enforced — the deck used Claude Design defaults. Fix: re-prompt with "use only the colors and fonts in the attached DESIGN.md; the current deck uses a font not in that file."
+- **Slide 7 invented stats.** Cause: README didn't have proof points; Claude filled in. Fix: re-prompt with "remove every claim not directly supported by the README; leave slide 7 thin."
+- **Diagrams look like Visio from 2008.** Cause: default diagram styling. Fix: comment inline "redraw this diagram using the brand's accent line weight and the body font, no clip-art arrows."
+- **12 slides feels thin.** Cause: README is more product-doc than pitch. Fix: tighten the README's problem + differentiation sections, regenerate. Don't pad slides.
+- **Slide 11 says "let's discuss."** Cause: weak prompt for the ask. Fix: re-prompt with the specific ask in your own words ("ask for $750k seed at $7M post" / "ask for 2 engineers + Q3 launch slot").
+- **Burns through quota fast.** Cause: deck generation is one of the heavier Claude Design operations. Fix: get the structure right in the first pass; iterate inline rather than regenerating from scratch.
+
+## References
+
+- [Anthropic — Claude Design launch](https://www.anthropic.com/news/claude-design) — pitch decks called out as a primary collateral surface
+- [Linas Beliūnas — Founder's Playbook](https://linas.substack.com/p/claude-design-founders-playbook) — deck workflow #5 in the 8-workflow set
+- [getpushtoprod — Everything You Need to Know](https://getpushtoprod.substack.com/p/everything-you-need-to-know-about) — 4-template workflow including Slide template
+- [Lenny's Newsletter — What Claude Design is actually good for](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) — slides covered as a top use-case
+- [Adweek — Anthropic debuts Claude Design for marketing assets, decks, UIs](https://www.adweek.com/media/anthropic-debuts-claude-design-for-building-marketing-assets-decks-and-uis/) — decks as a primary launch positioning
+- [Peter Yang — 16-min everything build](https://creatoreconomy.so/p/claude-design-everything-you-can-build) — deck generation included in the all-in-one demo

--- a/recipes/repo-to-design-system.md
+++ b/recipes/repo-to-design-system.md
@@ -1,0 +1,145 @@
+# Existing Repo → Design System
+
+Point Claude Design at a real codebase. Get back a canonical `DESIGN.md` that reflects what your CSS actually does — not what your style guide *claims* it does.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Generate a working design system from a live repository. Claude Design reads CSS variables, component files, and computed styles, then writes a `DESIGN.md` you can drop back into the repo as the source of truth.
+
+Per Linas Beliūnas's *Founder's Playbook*: Mercury reported Claude inferring **~90% of their design system directly from the codebase**. The remaining 10% is the editorial pass.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Pick the right scope (subdirectory, not monorepo) | 3 min |
+| 2. Connect the repo | 2 min |
+| 3. Run the inference prompt | 5 min |
+| 4. Edit the 10% Claude got wrong | 15 min |
+| 5. Commit `DESIGN.md` to the repo | 2 min |
+| **Total** | **~25–30 min** |
+
+## Inputs
+
+- A repo with a non-trivial CSS layer (Tailwind config, CSS vars, styled-components, or vanilla CSS)
+- GitHub access via the GitHub connector OR a public repo URL OR a local folder you can drag in
+- One existing component you trust to be "on-brand" (your reference truth)
+- ~30 min of editor time for the polish pass
+
+## Steps
+
+### 1. Pick the right scope — subdirectory, not monorepo
+
+Per *AI For Developers* ([How to Actually Use Claude Design](https://aifordevelopers.substack.com/p/how-to-actually-use-claude-design)): pointing Claude at a 200-package monorepo gets you nowhere. The context window chokes, inference quality degrades, and the resulting `DESIGN.md` is mush.
+
+Instead:
+
+- For a monorepo: point Claude at **one app** (e.g. `apps/marketing/`) or **one package** (`packages/ui/`)
+- For a single Next.js app: target `src/components/` + `tailwind.config.js` + `src/app/globals.css`
+- For a Rails / Django app: target `app/javascript/` or the equivalent component folder
+
+If you must cover a monorepo, run this recipe **once per package** and merge the resulting files manually. Don't ask Claude to do the merge — that's the editorial pass.
+
+### 2. Connect the repo
+
+Three options, ordered by quality of result:
+
+- **GitHub connector** (best) — Claude reads file-by-file, follows imports, sees the whole tree
+- **Repo URL paste** — Claude clones a snapshot; works for public repos
+- **Drag a `.zip`** — for private repos you can't expose; less reliable on file size limits (~25MB)
+
+### 3. Run the inference prompt
+
+```
+Read the codebase rooted at {subdirectory path or repo URL}. Focus on:
+
+- CSS variables (look in globals.css, theme.ts, tailwind.config.{js,ts})
+- Component primitives (Button, Card, Input, Nav, Modal — whichever exist)
+- Typography stack (font-family declarations + computed sizes)
+- Spacing scale (margin/padding patterns; Tailwind's `space-*`, CSS calc() chains)
+- Color usage (every hex / hsl / oklch reference, grouped by semantic role)
+
+Produce a DESIGN.md following the 9-section canonical format used in
+awesome-claude-design (see /design-md/<family>/*.md for examples):
+
+1. Visual Theme & Atmosphere — what kind of product this looks like
+2. Color Palette & Roles — every color, role-named (--bg, --accent, --surface)
+3. Typography Rules — font stack with fallbacks, modular scale extracted
+   from real font-size values
+4. Component Stylings — Button (primary/secondary), Card, Input, Nav minimum
+5. Layout Principles — max-width, grid, spacing scale
+6. Depth & Elevation — every shadow/border style detected
+7. Do's and Don'ts — inferred from consistent patterns in the code
+8. Responsive Behavior — breakpoints used, transition patterns
+9. Agent Prompt Guide — bias + reject clauses for future LLM use
+
+Each section ≤ 150 words. Hex only. No marketing copy.
+
+For every claim, cite the file + line you pulled it from. If a token is
+inferred not observed, label it "inferred" — don't fabricate.
+```
+
+### 4. Edit the 10% Claude got wrong
+
+The Mercury number is 90%. The other 10% is real:
+
+- **Color roles get crossed** — Claude may name your warning yellow `--accent` because it's used in a CTA somewhere
+- **Spacing scale collapses** — Tailwind's full scale (0.5, 1, 1.5, 2, 3, 4...) often gets compressed to (1, 2, 4, 8) in the inference
+- **Component variants missed** — secondary buttons used twice in a 200-component repo will be ignored
+- **Dark mode tokens** swallowed into light mode if your `dark:` prefixes aren't dense enough
+
+Open the `DESIGN.md` next to your component reference (the one you trust). For each section, ask: *would I onboard a new designer with this doc?* Edit until yes.
+
+### 5. Commit `DESIGN.md` to the repo
+
+Place it at `/DESIGN.md` (root) or `/docs/DESIGN.md`. Future Claude Design sessions on this repo will pick it up automatically as the design system file.
+
+```bash
+git add DESIGN.md
+git commit -m "add: canonical design system inferred from codebase"
+```
+
+For multi-package monorepos: one `DESIGN.md` per package (`packages/ui/DESIGN.md`, `apps/marketing/DESIGN.md`) — keep them scoped to what they describe.
+
+## Quality Checks
+
+- [ ] Every color in section 2 traces back to a file:line reference
+- [ ] Type stack matches the actual `font-family` cascade (fallbacks included)
+- [ ] Modular scale uses real values from your CSS, not the default 1.25 ratio
+- [ ] At least one "Don't" in section 7 cites a pattern you've actively rejected in code review
+- [ ] Spacing scale matches your Tailwind config (or equivalent) — not a Claude default
+- [ ] No `inferred` tokens hide in places that should be observed (re-prompt if so)
+- [ ] Dark mode coverage matches what your repo actually ships
+
+## Variations
+
+- **Refactor-driven:** run the recipe **before** a CSS refactor to capture current state, then re-run after to diff what changed
+- **Acquisition due-diligence:** run on the acquired company's repo to produce a design-system gap analysis
+- **Polyrepo merge:** generate `DESIGN.md` per repo, then run [`recipes/two-brand-remix.md`](#) (when shipped) to propose a unified system
+- **Storybook-first:** if you have Storybook, point Claude at `*.stories.tsx` files — variant coverage is much higher
+
+## Common Failures
+
+- **The inference is generic.** Cause: pointed Claude at the monorepo root; it averaged everything. Fix: scope to one package or app, re-run.
+- **Tokens look invented.** Cause: Claude couldn't access the file (private repo without connector auth). Verify by asking it to quote three real lines back. If it can't, fix the access.
+- **`DESIGN.md` already exists and got overwritten.** Cause: Claude regenerated from scratch instead of reconciling. Fix: rename the existing file before re-running, then merge by hand. Don't ask Claude to "merge with existing" — quality drops.
+- **Subdirectory has weird build artifacts.** Cause: Claude read `dist/`, `build/`, or `.next/` instead of source. Fix: explicitly say "read only `src/` and `tailwind.config.ts`, ignore `dist/` and `node_modules/`."
+- **Component coverage is patchy.** Cause: components live in 4 directories you didn't mention. Fix: re-prompt with the full directory list.
+
+## Case Studies
+
+- **Mercury — 90% codebase inference** ([Linas Beliūnas](https://linas.substack.com/p/claude-design-founders-playbook)) — banking interface design system reconstructed from production CSS
+- **Brilliant — 20→2 prompts** ([Anthropic launch post](https://www.anthropic.com/news/claude-design)) — interactive lessons platform; iteration count dropped 10× once `DESIGN.md` existed
+- **Datadog — week → 1 conversation** ([Anthropic launch post](https://www.anthropic.com/news/claude-design)) — observability dashboard design system inference
+
+## References
+
+- [Linas Beliūnas — Founder's Playbook](https://linas.substack.com/p/claude-design-founders-playbook) — Mercury 90% inference cited
+- [AI For Developers — How to Actually Use Claude Design](https://aifordevelopers.substack.com/p/how-to-actually-use-claude-design) — subdirectory-not-monorepo gotcha
+- [Anthropic — Claude Design launch](https://www.anthropic.com/news/claude-design) — Brilliant + Datadog case studies
+- [google-labs-code/design.md spec](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md) — the canonical DESIGN.md format
+- [Mejba Ahmed — Claude Design as the visual layer Claude Code was missing](https://www.mejba.me/blog/claude-design-visual-workflow-claude-code) — engineer-side workflow notes

--- a/recipes/web-capture-to-prototype.md
+++ b/recipes/web-capture-to-prototype.md
@@ -1,0 +1,139 @@
+# Web Capture → Prototype
+
+Use Claude Design's native web capture to grab live elements from your production site, then build a prototype that matches reality — not a Figma file that drifted six releases ago.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Capture a live page (or specific elements within it) directly inside Claude Design, then prototype a new flow on top. The prototype inherits the production tokens — type, color, component shape — without anyone exporting tokens by hand.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Open Claude Design + paste URL | 1 min |
+| 2. Select capture targets | 3 min |
+| 3. Brief the prototype | 2 min |
+| 4. Generate + inline-tweak | 8 min |
+| 5. Bundle to Claude Code (optional) | 1 min |
+| **Total (capture-only)** | **~15 min** |
+
+## Inputs
+
+- A public URL — production site, marketing page, or web app preview
+- A clear ask: *what new flow am I prototyping on top of this?*
+- Pro / Max / Team / Enterprise Claude plan (web capture is gated)
+- Optional: an existing `DESIGN.md` for the same brand to cross-check token extraction
+
+## Steps
+
+### 1. Open Claude Design + paste URL
+
+In a new Claude Design session, paste the URL into the prompt box. Claude offers two read modes:
+
+- **Page capture** — entire viewport at one or more breakpoints
+- **Element capture** — pick specific components (hero, nav, pricing card)
+
+For prototyping a new flow that should *feel native*, element capture beats page capture. Less noise.
+
+### 2. Select capture targets
+
+Concrete picks that actually matter:
+
+- **Primary nav** — proves your prototype's chrome matches
+- **Hero** — establishes type scale + accent usage in context
+- **Primary CTA** — button shape, hover state, color role
+- **One content card** — proves card geometry (radius, shadow, padding)
+- **Footer** — easy to forget, easy to make wrong
+
+Skip: ad units, third-party embeds, anything in an iframe. Capture quality drops on those.
+
+### 3. Brief the prototype
+
+```
+Capture the following elements from {URL}:
+- Top navigation
+- Hero section
+- Primary CTA button (in any state)
+- One representative content card
+- Footer
+
+Extract the actual computed CSS for each. Build a DESIGN.md-shaped
+internal token sheet from what you captured (color roles, type scale,
+spacing rhythm, radius, shadow). Show me the token sheet before
+generating any prototype.
+
+Then prototype a new flow on top of this captured system:
+
+{ describe the flow — e.g. "a 3-step onboarding wizard that lives at
+/welcome, matches the home page chrome, and uses the same primary
+CTA shape" }
+
+Constraints:
+- Use only the tokens you captured. Do not invent new colors or fonts.
+- Match the spacing rhythm of the captured page within ±4px.
+- New components (Stepper, ProgressBar) must be derived from existing
+  primitives — don't invent a third button style.
+```
+
+The "show me the token sheet first" line is doing real work. It catches mismatches before you spend cycles on a prototype built on bad tokens.
+
+### 4. Generate + inline-tweak
+
+Once the token sheet looks right, let it generate. Then comment inline on:
+
+- **Spacing inconsistencies** — your prototype's hero should breathe like the captured one
+- **One-too-many accent colors** — capture often pulls a secondary accent that wasn't in your DESIGN.md
+- **Type weight drift** — captured CSS sometimes reads display weight as `600` when it's actually `700` due to OS rendering. Verify against the live page.
+
+Use specific, element-level comments. "The third onboarding step's CTA reads thinner than the home-page CTA — match weight."
+
+### 5. Bundle to Claude Code (optional)
+
+Same flow as [`landing-page-20-min.md`](landing-page-20-min.md): **Bundle → Claude Code**, paste the prompt in your terminal. Claude Code receives the prototype scaffold + the captured token CSS variables + component stubs.
+
+```bash
+npm install
+npm run dev
+```
+
+If your production site is a Next.js app, you can drop the new flow at `/welcome` and it will render against your existing `globals.css` with no token conflicts.
+
+## Quality Checks
+
+- [ ] Token sheet was reviewed before prototype generation (not after)
+- [ ] Captured CTA matches the production CTA's shape, weight, and color exactly
+- [ ] No invented accent colors (compare prototype palette to capture sheet)
+- [ ] Spacing rhythm holds within ±4px of captured baseline
+- [ ] New components (Stepper, ProgressBar) are derived from existing primitives, not net-new
+- [ ] If bundled to Claude Code: dev server renders the new flow against production `globals.css` without overrides
+- [ ] Mobile breakpoint captured separately if your site has distinct mobile chrome
+
+## Variations
+
+- **Auth-gated app capture:** capture is public-only at launch. For dashboards behind auth, screenshot the relevant views and drag them in alongside a public marketing URL for the brand chrome.
+- **Competitor capture for moat research:** capture a competitor's pricing page, then prototype your own pricing in *your* DESIGN.md to test "would mine convert better?"
+- **Component library audit:** capture every page on your site, ask Claude to flag inconsistencies (3 button styles where there should be 2)
+- **Pre-redesign baseline:** capture before refactor to lock the current visual contract; replay after refactor to verify nothing regressed
+- **Multi-breakpoint capture:** capture the same page at 375 / 1024 / 1440 to extract the responsive token deltas (especially `clamp()` ranges)
+
+## Common Failures
+
+- **Captured tokens don't match the production site at runtime.** Cause: capture grabbed a stale CDN'd CSS file. Fix: hard-refresh the URL, recapture; or paste the URL with a cache-busting query param.
+- **Hero looks right, but card geometry is off.** Cause: Claude only captured one card; your site has three card variants. Fix: explicitly list each card type to capture by URL anchor.
+- **The new flow feels generic despite capture.** Cause: Claude defaulted to its own component library and only used your tokens for color. Fix: re-prompt with "use the captured Button primitive verbatim — same border-radius, same padding-y, same font-weight."
+- **`clamp()` type scaling looks wrong in the prototype.** Cause: capture happened at one viewport. Fix: recapture at 375 + 1024 + 1440, ask Claude to extract the scaling formula.
+- **Capture missed an iframe-embedded section.** Cause: Claude can't see across iframe boundaries. Fix: provide the iframe's source URL separately, or screenshot.
+- **"Web capture is unavailable on your plan."** Cause: Free / personal plan without Claude Design enabled. Fix: upgrade or run on a Pro account.
+
+## References
+
+- [Anthropic — Claude Design overview](https://www.anthropic.com/news/claude-design) — feature listing for web capture
+- [Department of Product — 5 examples + GitHub mock setup](https://departmentofproduct.substack.com/p/claude-design-is-here-everything) — capture used in walkthrough #3
+- [Sorted Pixels — Claude for Designers Ultimate Guide](https://nervegna.substack.com/p/claude-for-designers-the-ultimate) — three-tier framing covers capture as "practitioner" move
+- [DesignerUp — How to Use Claude Design for UX/UI](https://designerup.co/blog/how-to-use-claude-design-for-ux-ui/) — capture-then-iterate workflow
+- [BSWEN — Good Enough for Professional Websites?](https://docs.bswen.com/blog/2026-04-18-claude-design-quality-professional/) — quality bar discussion (relevant when prototyping for production)
+- [Lenny's Newsletter — What Claude Design is actually good for](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) — capture covered in landing-page workflow


### PR DESCRIPTION
Fills three README workflow stubs with full recipe files and adds one net-new recipe sourced from Ryan Mather's connectors tip.

## What ships

### `recipes/connectors-slack-docs.md` — net-new

Wires Slack threads, Google Docs, and Drive folders into Claude Design as first-class context. Built around Mather's tip 4: *"Read the notes from yesterday's product roast meeting and create a deck that addresses every concern."* Includes a verification step (paste back recent timestamps before generating) to catch silent connector failures, and a quota-aware iteration pattern (bundle the connector read into the first prompt; don't re-trigger on every turn).

### `recipes/repo-to-design-system.md` — fills README workflow #3

End-to-end recipe for inferring a `DESIGN.md` from a real codebase. Anchored on the Mercury 90% codebase inference number (Linas Beliūnas's *Founder's Playbook*) and the subdirectory-not-monorepo gotcha (AI For Developers). Cites Brilliant (20→2 prompts) and Datadog (week→1 conversation) as case studies. Includes the editorial pass for the remaining 10% — color role crossings, spacing-scale collapse, missed component variants, dark-mode swallowing.

### `recipes/web-capture-to-prototype.md` — fills README workflow #8

Native web capture flow: paste URL, pick element-level capture targets, brief the prototype against the captured token sheet. Gates the prototype generation behind a "show me the token sheet first" prompt to catch token mismatches before they propagate. Covers `clamp()` capture at three viewport widths and the auth-gated dashboard workaround.

### `recipes/pitch-deck-from-readme.md` — fills README workflow #5

12-slide deck from any README, with the README audit step front-loaded (lede / problem / differentiation / proof). Audience-keyed DESIGN.md picks (editorial for VCs, terminal/data-dense for devs, cinematic for creators). Slide-level prompt block with named per-slide intent, plus the three slides (1, 6, 12) that carry disproportionate weight.

## README change

`## Workflows & Recipes` items 3, 5, 8 converted from bare text to file links. Numbering 1-13 preserved exactly.

## Out of scope

Banner, hero, gallery, anti-slop, family tables, comparisons, community takes, FAQ — all untouched.