### PR TITLE
add: Podcast Coverage section (Lenny + AI Daily Brief + Design Better + more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ What each aesthetic family actually looks like in production. Thumbnails are sta
 - [Workflows & Recipes](#workflows--recipes)
 - [Long-Form Tutorials](#long-form-tutorials)
 - [Tips & Tricks](#tips--tricks)
+- [Podcast Coverage](#podcast-coverage)
 - [FAQ](#faq)
 - [Related OSS Projects](#related-oss-projects)
 - [Tag System](#tag-system)
@@ -810,6 +811,20 @@ Anthropic insider, posted day two of launch.
 
 - **Connectors to Slack and docs** are the single highest-leverage integration for brand consistency, but also the fastest way to burn weekly allowance. Wire them only on production projects, not exploration.
 - **Subdirectory, not monorepo.** Per [AI For Developers](https://aifordevelopers.substack.com/p/how-to-actually-use-claude-design), point Claude Design at one subdirectory per project — full-monorepo context is slow and noisy. One `DESIGN.md` per app, linked from the subdirectory.
+
+## Podcast Coverage
+
+The audio coverage worth queueing. Insider interviews, launch-week reactions, and adjacent context from the v0 / generative-web orbit.
+
+- [Lenny's Podcast — Jenny Wen (head of design at Claude, ex-Figma director), "the design process is dead"](https://www.lennysnewsletter.com/p/the-design-process-is-dead) — anchor episode (March 1, 2026, 1h 17m). Predates launch but lays the philosophical foundation: discovery → mock → iterate is dead, three designer archetypes Anthropic hires, AI taste/judgment, why she left Figma director to return to IC at Anthropic.
+- [Lenny's Newsletter mini-episode (Apr 22) — "What Claude Design is actually good for"](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) — post-launch reaction. Companion YouTube: ["Claude Design is slow and I love it anyway"](https://www.youtube.com/watch?v=wgPVh9wG6Ok). Landing page + slides + unhinged-redesign tests; CD + GPT Images 2.0 + DESIGN.md side-by-side.
+- [AI Daily Brief (Nathaniel Whittemore) — Claude Design episode](https://podcasts.apple.com/us/podcast/the-ai-daily-brief-artificial-intelligence-news/id1680633614) — largest daily AI podcast covering CD; non-design AI audience reach. Best use cases first few days; marketing / decks / wireframes / launch-videos. Companion [Claude Cowork episode](https://open.spotify.com/episode/5krjdNlepb26fNWmcsRjG9).
+- [Design Better Podcast — "The Roundup: Our first impressions of Claude Design"](https://designbetterpodcast.com/p/the-roundup-our-first-impressions) — designer-host roundtable. "The interesting problem isn't generating pixels — it's generating pixels that look like *your* product." Not-a-Figma-killer-yet read.
+- [Design Better Podcast — Meaghan Choi (Anthropic Product Designer on Claude Code)](https://www.designbetter.co/podcast) — adjacent context: Anthropic designer perspective on the broader Claude product surface (exact episode pending).
+- [Sequoia Training Data — Vercel CEO Guillermo Rauch: Building the Generative Web with AI](https://sequoiacap.com/podcast/training-data-guillermo-rauch/) — adjacent context for the v0 / generative-web side of the same wave.
+- [Lenny's Podcast — "Everyone's an engineer now: Inside v0's mission" (Guillermo Rauch)](https://www.lennysnewsletter.com/p/everyones-an-engineer-now-guillermo-rauch) — Rauch episode; v0 framing useful for comparison content.
+- [AI and I — Vercel's Guillermo Rauch on What Comes After Coding](https://creators.spotify.com/pod/profile/how-do-you-use-chat-gpt/episodes/Vercels-Guillermo-Rauch-on-What-Comes-After-Coding---Ep--47-e2tguf3) — third Rauch take; complements the Sequoia + Lenny episodes.
+- [How I AI — "Claude Code for Product Managers"](https://www.lennysnewsletter.com/p/this-week-on-how-i-ai-claude-code) — adjacent PM-focused context; CC perspective applicable to CD workflows.
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

Adds a new top-level `## Podcast Coverage` section to `README.md`, between `## Tips & Tricks` and `## FAQ`. Updates the Contents anchor list to match. No other sections touched. No new files.

The anchor episode is Jenny Wen (head of design at Claude, ex-Figma director) on Lenny's Podcast — **\"the design process is dead. Here's what's replacing it.\"** It predates the Claude Design launch but lays the philosophical foundation nothing else matches: discovery → mock → iterate is dead, three designer archetypes Anthropic hires, AI taste/judgment, why she left Figma director to return to IC at Anthropic.

## Episodes added

- **Lenny's Podcast — Jenny Wen (anchor episode):** https://www.lennysnewsletter.com/p/the-design-process-is-dead — \"the design process is dead\"
- **Lenny's mini-episode (post-launch reaction, Apr 22):** https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good — companion YouTube https://www.youtube.com/watch?v=wgPVh9wG6Ok
- **AI Daily Brief (Nathaniel Whittemore) — Claude Design episode:** https://podcasts.apple.com/us/podcast/the-ai-daily-brief-artificial-intelligence-news/id1680633614 — companion Claude Cowork episode https://open.spotify.com/episode/5krjdNlepb26fNWmcsRjG9
- **Design Better Podcast — \"The Roundup: Our first impressions of Claude Design\":** https://designbetterpodcast.com/p/the-roundup-our-first-impressions
- **Design Better Podcast — Meaghan Choi (Anthropic Product Designer on Claude Code):** https://www.designbetter.co/podcast (exact episode pending)
- **Sequoia Training Data — Guillermo Rauch (v0 / generative web):** https://sequoiacap.com/podcast/training-data-guillermo-rauch/
- **Lenny's Podcast — \"Everyone's an engineer now: Inside v0's mission\" (Rauch):** https://www.lennysnewsletter.com/p/everyones-an-engineer-now-guillermo-rauch
- **AI and I — Vercel's Guillermo Rauch on What Comes After Coding:** https://creators.spotify.com/pod/profile/how-do-you-use-chat-gpt/episodes/Vercels-Guillermo-Rauch-on-What-Comes-After-Coding---Ep--47-e2tguf3
- **How I AI — \"Claude Code for Product Managers\":** https://www.lennysnewsletter.com/p/this-week-on-how-i-ai-claude-code

## Notes

- Direct URLs used for every episode where the addendum doc had one. Where only a show homepage was available (Design Better — Meaghan Choi episode) the line is annotated \"exact episode pending.\"
- Section intro frames the list: insider interviews (Wen), launch-week reactions (mini-episode, AI Daily Brief, Design Better roundup), and adjacent context from the v0 / generative-web orbit (Rauch x3, How I AI).
- Contents anchor inserted between `Tips & Tricks` and `FAQ` to mirror the section placement.

## Test plan

- [ ] Section renders between `## Tips & Tricks` and `## FAQ`
- [ ] Contents anchor link `#podcast-coverage` jumps to the new section
- [ ] All eight (nine including companion links) URLs resolve
- [ ] No other sections modified (verify with `git diff --stat` — single file, +15 -0)