### PR TITLE
add: 8 showcase wave-2 entries (Ileana 3D Helix, Austin Lau, CopyRocket, Anthropic bundled examples + more)

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -21,6 +21,18 @@ No promo speak, no rendered mockups posing as shipped product. Real builds only.
 | **Datadog** | Whole-week design review cycle collapsed into one Claude Design conversation | [anthropic.com — launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) | **1 week → 1 conversation** |
 | **Lenny Rachitsky** | "Unhinged Redesign" experiment — pushed Claude Design to extremes to find the breaking point | [lennysnewsletter.com](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) | Adversarial test, surfaces good vs hype |
 
+## Wave 2 — frontier features, brand tests, bundled examples
+
+| Builder | What they built | Link | Time / notable detail |
+|---|---|---|---|
+| **Ileana Marcut** | 3D Helix portfolio with shaders — only published shader/3D worked example with full prompts inside | [ileanamarcut.substack.com](https://ileanamarcut.substack.com/p/claude-design) | Replicable shader/3D recipe, anchors the frontier-features slot |
+| **Austin Lau** (Anthropic) | Claude Cowork landing-page recreation — first-party demo of Tweaks panel reordering + variant swap + handoff to Claude Code | [x.com/helloitsaustin](https://x.com/helloitsaustin/status/2045176910569980318) | Best documentation of the no-regen sidebar workflow |
+| **AI Adopters Club** | FleetPulse — fictional Series A startup walked end-to-end in six prompts with blank templates for swap-in | [aiadopters.club](https://aiadopters.club/p/claude-design-just-launched-and-here) | **6 prompts**, "test it in an afternoon" |
+| **PushToProd** | Pomodoro design system with Mac OS aesthetic animation — generated transitions/motion graphics, runs natively in browser | [getpushtoprod.substack.com](https://getpushtoprod.substack.com/p/everything-you-need-to-know-about) | **5 hours** of testing, animation applied to existing system |
+| **Ben Peetermans** (launchwithben) | Hands-on brand kit + landing page test, engineer-spends-hours review with concrete observations | [dev.to/launchwithben](https://dev.to/launchwithben/claude-design-review-hands-on-brand-kit-and-landing-page-test-38l1) | Engineer POV, brand-kit-to-landing flow |
+| **CopyRocket AI** | Real-brand landing + video + deck combo at concrete USD costs — definitive token-budget reference | [copyrocket.ai](https://copyrocket.ai/i-tested-claude-design-on-my-real-brand) | **$3 landing / $4 video / $7 deck** on Max-5x; 90% weekly burn in 4–5 prompts |
+| **Anthropic — bundled examples** | Nine official example projects shipped with the launch (shader wallpapers + 8 more) accessible via the Examples tab with "Use this prompt" | [anthropic.com — launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) | Official starter set, shader wallpapers are the showstopper |
+
 ## Format for new entries
 
 When you add a row, keep it to four columns: **Builder · What they built · Link · Time / notable detail**. One line per build. If your story needs more space, drop a `showcase/<slug>.md` alongside this README and link it from the table.


### PR DESCRIPTION
Appends a `## Wave 2 — frontier features, brand tests, bundled examples` table to `showcase/README.md`. Same four-column format as the launch-week seed (Builder · What · Link · Time/notable detail). Root `README.md` already points to `showcase/README.md` and is untouched.

## Cards added (7)

- **Ileana Marcut — 3D Helix portfolio** — https://ileanamarcut.substack.com/p/claude-design — only published shader/3D worked example with full prompts inside; anchors the frontier-features (3D/voice/shaders) recipe slot.
- **Austin Lau (Anthropic) — Cowork landing-page recreation** — https://x.com/helloitsaustin/status/2045176910569980318 — first-party demo of Tweaks panel reordering + variant swap + handoff to Claude Code; best documentation of the no-regen sidebar workflow.
- **AI Adopters Club — FleetPulse** — https://aiadopters.club/p/claude-design-just-launched-and-here — fictional Series A startup walked end-to-end in six prompts with blank templates.
- **PushToProd — Pomodoro design system** — https://getpushtoprod.substack.com/p/everything-you-need-to-know-about — applied Mac OS aesthetic animation to existing Pomodoro design system after 5 hours of testing.
- **Ben Peetermans (launchwithben) — brand kit + landing page test** — https://dev.to/launchwithben/claude-design-review-hands-on-brand-kit-and-landing-page-test-38l1 — engineer-spends-hours hands-on review.
- **CopyRocket AI — landing/video/deck combo at concrete USD costs** — https://copyrocket.ai/i-tested-claude-design-on-my-real-brand — \$3 landing / \$4 video / \$7 deck on Max-5x; 90% weekly burn in 4–5 prompts; definitive token-budget reference.
- **Anthropic — nine bundled examples** — https://www.anthropic.com/news/claude-design-anthropic-labs — official starter set accessible via the Examples tab with "Use this prompt"; shader wallpapers are the showstopper.

## Dropped

- **eMeRiKa — early-adopter iOS Markdown viewer build** — no public URL surfaced (deep-source-mining doc explicitly notes "need handle URL"). Per the no-broken-links policy, dropped rather than shipped.

## Scope

- Touched: `showcase/README.md` only (12-line append).
- Untouched: root `README.md`, all DESIGN.md files, prompts, recipes, assets, templates.