### PR TITLE
add: 4 workflow recipes (frontier 3D/shaders, tweaks panel, comment workaround, speaker notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,10 @@ End-to-end flows in `/recipes/<name>.md`.
 11. **Claude Design → Canva export** — designer collaboration pathway
 12. **Org-wide design-system sharing** — view-only URL, group-chat edit mode
 13. [**Token budget for Claude Design**](recipes/token-budget-claude-design.md) — ship a project on a single Pro plan in a week without burning quota
+14. [**Frontier 3D / shaders / voice / video**](recipes/frontier-3d-shaders.md) — build with Claude Design's native generation surfaces; cites Anthropic launch + Ileana Marcut's 3D Helix portfolio
+15. [**Tweaks panel — no-regen iteration**](recipes/tweaks-panel-sidebar.md) — reorder sections and swap variants without burning chat tokens; Austin Lau's sidebar workflow
+16. [**Comment-paste workaround**](recipes/comment-paste-workaround.md) — paste the would-be chat prompt as an inline comment; the MacStories "95%" pattern
+17. [**Speaker notes from a pitch deck**](recipes/speaker-notes-pitch-deck.md) — extract delivery-ready notes from a generated deck; pairs with `pitch-deck-from-readme`
 
 <p align="center"><img src="assets/mascot.svg" width="72" alt="mascot"></p>
 

--- a/recipes/comment-paste-workaround.md
+++ b/recipes/comment-paste-workaround.md
@@ -1,0 +1,149 @@
+# Comment-Paste Workaround
+
+When a full chat re-prompt would cost too much weekly allowance, paste the would-be prompt as an inline comment on the element instead. Same intent, fraction of the tokens.
+
+<img src="../assets/tags/community.svg" alt="community"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Get the precision of a written prompt without paying the full chat-regeneration cost. The community-discovered move (catalyzed by [MacStories' "comment-on-element covers 95%" observation](https://www.macstories.net/stories/hands-on-with-anthropic-labs-claude-design-preview/)): when you find yourself about to type a long chat prompt, stop, right-click the specific element, and paste the prompt into the comment field instead.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Catch yourself about to chat | 3 sec |
+| 2. Right-click the target element | 2 sec |
+| 3. Paste the would-be prompt as a comment | 30 sec |
+| 4. Wait for local re-render | 20–60 sec |
+| 5. Iterate or move on | — |
+| **Total** | **~1 min, low token cost** |
+
+## Inputs
+
+- A generated artifact open in Claude Design
+- A specific element you want to change (button, card, image, heading, section)
+- The exact prompt you would otherwise have typed in chat
+
+## Why this works
+
+Chat re-prompts re-load the entire artifact into vision context every turn. A 4-screen prototype at iteration 6 might be eating 80k+ vision tokens per chat round just to re-derive what's already on the canvas.
+
+Inline comments scope the operation to a single element. Claude Design re-renders that element (and whatever depends on it) without re-deriving the whole scene. Per [Ryan Mather's tip 2](https://x.com/Flomerboy/status/2045162321589252458), comments are the canonical move for component-level edits.
+
+The MacStories piece pushed this further: even prompts that *feel* like they need full chat — voice / phrasing / iconography swaps across a whole section — often work as comments on the section header. "95% of what's needed" was the framing, and the launch-week iteration data backs it.
+
+## Steps
+
+### 1. Catch yourself
+
+The discipline is hard. Most users default to chat because it's the most prominent surface. Build the reflex: every time you start typing in the chat box, ask "could this be a comment instead?"
+
+If the answer is "yes" or "maybe" — close the chat box, comment instead.
+
+### 2. Right-click the target
+
+In the canvas, right-click (or two-finger click on Mac) the element you want to change. The comment popover appears anchored to that element.
+
+If the element is a section header, your comment scopes to the whole section. If it's a single button, it scopes to that button. Pick the smallest scope that captures the change.
+
+### 3. Paste the would-be prompt
+
+Take the prompt you were about to type in chat — *exactly the same words* — and paste it into the comment field. Don't shorten it. Don't water it down. Comments accept the same prompt language chat does.
+
+Examples of prompts that work as comments:
+
+```
+On a hero headline:
+"Rewrite this with more confidence — drop the hedging.
+The current copy says 'might help you ship'; aim for
+'ships your design system in 20 minutes.'"
+```
+
+```
+On a feature card:
+"Replace the icon with one that matches the editorial
+family — current icon reads as a generic SaaS lucide
+icon. Use a custom illustration in the brand palette."
+```
+
+```
+On a section header:
+"Tighten this whole section. Cut the third feature card,
+move the CTA up, reduce the section padding by one step
+on mobile. Keep the same copy."
+```
+
+```
+On a deck slide:
+"Re-write the speaker notes for this slide in a more
+direct voice. Current notes are too presenter-y. Aim for
+the voice in slide 1's notes."
+```
+
+That last one — speaker notes edits — is one most people reach for chat on. Comment-on-slide handles it.
+
+### 4. Wait for the local re-render
+
+Component re-renders are 20–60 seconds. Section re-renders are slightly longer. You can keep working in another part of the canvas while it processes.
+
+### 5. Iterate or move on
+
+If the comment landed: move on. If it didn't: refine the comment on the same element rather than escalating to chat. Three comment iterations on one element still cost less than one chat re-prompt of the full artifact.
+
+## When this is the right move (and when it isn't)
+
+**Use comment-paste for:**
+
+- Voice / phrasing changes scoped to a section
+- Icon / image / illustration swaps
+- Layout tweaks within a single component
+- Speaker-notes rewrites on a deck slide
+- Color / weight / spacing adjustments to a heading or CTA
+- Removing or adding a single feature card / row / item
+- "Make this more X" prompts where X is local (more confident, more compact, more on-brand)
+
+**Use chat for:**
+
+- Adding a whole new section that doesn't exist yet
+- Changing the page intent ("this is now a pricing page, not a product page")
+- Conceptual pivots ("redo for a B2C audience instead of B2B")
+- Re-deriving the whole token system
+
+A working test: if you can point at the change with your finger, comment. If you can't, chat.
+
+## Quality Checks
+
+- [ ] Caught yourself before typing the chat prompt
+- [ ] Comment scope is the smallest element that captures the change
+- [ ] Prompt language is the same precision as chat — not watered down
+- [ ] Re-render produced what you wanted (don't accept "close enough" silently)
+- [ ] If three comment iterations didn't land, you escalated to chat rather than spamming comments
+- [ ] You logged which prompt patterns work as comments — internalizing for next session
+
+## Variations
+
+- **Speaker-notes-only edits on a deck** — every notes rewrite via comment-on-slide; reserve chat for new slides only
+- **Whole-section voice rewrite** — comment on the section header, write the prompt there; Claude rewrites all child copy in one local pass
+- **Iconography pass** — go through every icon on a page, comment-replace each. Faster than asking chat to "review all icons"
+- **Mobile-only adjustments** — comment with "mobile only: tighten padding by one step, hide the secondary CTA"; Claude scopes the change to the mobile breakpoint
+- **Empty-state polish** — empty states almost always need 3–5 small fixes. Comment them all instead of one big chat prompt
+
+## Common Failures
+
+- **Comment didn't trigger a re-render.** Cause: comment was on the canvas background, not on an element. Fix: right-click *on* the element (button, card, image), not next to it. Look for the popover anchor visual.
+- **Re-render changed more than you wanted.** Cause: comment scope was the section header, not the specific child. Fix: comment on the smaller element next time. Or comment with explicit scope: "only the third card, not the others."
+- **You watered down the prompt.** Cause: comments feel like they should be short. Fix: comments accept the same prompt complexity chat does. Paste the full prompt.
+- **Three comments in, still not right.** Cause: the change is actually structural, not local. Fix: escalate to chat. The comment-paste workaround is for component-level work; structural changes need full chat context.
+- **You forgot which element you commented on.** Cause: comments are anchored visually but easy to lose track of in a long iteration session. Fix: open the comments panel periodically; resolve completed comments to keep the canvas clean.
+- **Burned quota anyway because of comment volume.** Cause: ten comments at once, each triggering a partial re-render. Fix: batch related comments before triggering re-render; or pause briefly between comments to let one finish before the next.
+
+## References
+
+- [MacStories — Hands-On with Anthropic Labs' Claude Design Preview](https://www.macstories.net/stories/hands-on-with-anthropic-labs-claude-design-preview/) — the "comment-on-element covers 95% of what's needed" observation that named this pattern
+- [Ryan Mather — 7 tips for Claude Design](https://x.com/Flomerboy/status/2045162321589252458) — tip #2 ("Comment, don't chat") is the broader version of this
+- [Austin Lau (Anthropic) — Tweaks panel demo](https://x.com/helloitsaustin/status/2045176910569980318) — pairs cleanly: Tweaks for layout, comments for components, chat for structure
+- [`recipes/tweaks-panel-sidebar.md`](tweaks-panel-sidebar.md) — the layout-level half of the no-regen iteration model
+- [`recipes/token-budget-claude-design.md`](token-budget-claude-design.md) — Phase 3 of the broader budget recipe is built on this exact workaround

--- a/recipes/frontier-3d-shaders.md
+++ b/recipes/frontier-3d-shaders.md
@@ -1,0 +1,150 @@
+# Frontier Features — 3D, Shaders, Voice, Video
+
+Claude Design ships native generation for the surfaces that previously needed Three.js, Spline, ElevenLabs, or Runway. This recipe covers how to actually use them — and the one public worked example to study before you start.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Build a real frontier feature — a 3D hero, an animated shader background, a voice walkthrough, or a 90-second brand video — inside one Claude Design session. Avoid the trap of treating the frontier surfaces as gimmicks; treat them as design primitives with their own constraints.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Pick the surface + reference | 5 min |
+| 2. Brief Claude Design with constraints | 4 min |
+| 3. First generation pass | 3–8 min (depends on surface) |
+| 4. Tighten via inline comments | 10 min |
+| 5. Export to the right format | 3 min |
+| **Total** | **~25–30 min** |
+
+## Inputs
+
+- A `DESIGN.md` from `/design-md/<family>/` so the frontier output inherits your system tokens (color, type, motion)
+- One concrete surface picked: 3D scene · shader background · voice narration · short brand video
+- A reference (one URL, one screenshot, or one short description of the motion you want)
+- A target context: where this lives — hero section, loading state, splash screen, demo page
+
+## Surfaces, briefly
+
+Per the [Anthropic launch post](https://www.anthropic.com/news/claude-design-anthropic-labs), Claude Design ships native generation for **Voice, Video, 3D, and Shaders** alongside the standard prototype/deck/page surfaces. Each has different cost and iteration shape:
+
+| Surface | What it's good for | What it's not |
+|---|---|---|
+| **3D** | Hero objects, product spins, abstract geometry | Full game scenes, physics simulations |
+| **Shaders** | Animated backgrounds, gradient fields, hover effects | Photorealistic textures, video-quality lighting |
+| **Voice** | Narration over a deck, an audio walkthrough, accessibility passes | Multi-character dialogue, music |
+| **Video** | 30–90s brand films, screen-recording-style demos | Long-form (>2 min), live action, complex VFX |
+
+## Steps
+
+### 1. Pick the surface + reference
+
+Don't let Claude pick. Walk in with a decision: *"3D helix as the hero, slowly rotating, brand-accent gradient on the strands."* Vague briefs ("make it pop with 3D") burn tokens generating things you'll throw away.
+
+Reference shapes that work:
+
+- **For 3D** — a still screenshot of the geometry you want, or a CodePen URL
+- **For shaders** — a `.glsl` snippet you like, or "the [Vercel](https://vercel.com) hero gradient"
+- **For voice** — 1–2 paragraphs of narration text + a tone descriptor ("warm, deliberate, no hype")
+- **For video** — a moodboard URL, a competitor's hero video, or "screen-recording style with terminal cursor"
+
+### 2. Brief Claude Design
+
+Use this template — the constraint blocks matter most.
+
+```
+Build a {3D scene / shader background / voice narration / brand video}
+for the {hero / loading state / demo page / about page}.
+
+Reference: {paste URL or describe in one sentence}
+
+Use the attached DESIGN.md as the source of truth for color, type,
+motion easing, and accent placement. The frontier output must inherit
+the same tokens — do not introduce new colors or fonts.
+
+Constraints:
+ - Surface: {explicit format — WebGL canvas / GLSL fragment shader /
+   MP3 narration / MP4 video at 1920x1080}
+ - Duration / size: {3D = "loops every 8s" / shader = "60fps target" /
+   voice = "under 90s" / video = "under 60s"}
+ - Performance budget: {must run on mid-tier laptop without fan spin /
+   under 200KB shader code / under 2MB MP3 / under 10MB MP4}
+ - Accessibility: {prefers-reduced-motion fallback / captions for
+   voice + video / static frame fallback for 3D + shader}
+
+Output one version. I will iterate inline; do not generate variants
+in this pass.
+```
+
+Drag the `DESIGN.md` into the chat with the brief.
+
+### 3. First generation pass
+
+Frontier surfaces take longer than a 2D page — budget 3–8 minutes for the first paint depending on surface:
+
+- **3D** — 3–5 min (geometry + materials + lighting)
+- **Shaders** — 1–2 min (single fragment shader is fast)
+- **Voice** — 1–2 min (TTS render)
+- **Video** — 5–8 min (longest; multi-frame composition)
+
+Don't refresh or re-prompt during this. Each false start re-loads vision context and burns weekly allowance. See the [token budget recipe](token-budget-claude-design.md) for the full spend model.
+
+### 4. Tighten via inline comments
+
+This is where frontier output usually breaks. Default 3D scenes are too busy, default shaders are too saturated, default voice is too announcer-y, default video is too montage-cut. Comment specifically on the failure:
+
+- **3D** — "the helix rotation is too fast — slow to one revolution per 12 seconds" / "ambient light is washing out the accent — drop ambient by 40%"
+- **Shaders** — "the noise pattern is too high-frequency — scale the noise period 2x" / "the gradient stops are at 50%, push to 30/70"
+- **Voice** — "the narrator sounds rushed in sentence 2 — add a 0.4s pause after 'we shipped'" / "drop the upward inflection on 'right?'"
+- **Video** — "cut 1 (logo zoom) is too aggressive — replace with a slow dolly-in over 3s" / "the title card holds too long — trim to 1.2s"
+
+Inline comments are massively cheaper than chat re-prompts on frontier surfaces because the renderer reuses the existing scene/audio/video and edits in place. (See Austin Lau's [Tweaks demo](https://x.com/helloitsaustin/status/2045176910569980318) for the same pattern on 2D layouts.)
+
+### 5. Export
+
+| Surface | Best export |
+|---|---|
+| 3D | `<canvas>` + Three.js scene file, or compiled GLB for a portfolio |
+| Shader | GLSL fragment + a JS wrapper, or compiled MP4 loop for sites without WebGL |
+| Voice | MP3 + WebVTT captions in one zip |
+| Video | MP4 (H.264) + a poster frame PNG; ask for a vertical 9:16 cut if you need socials |
+
+## Quality Checks
+
+- [ ] The frontier output uses the DESIGN.md accent color, not a default purple/teal
+- [ ] Motion eases match DESIGN.md easing tokens (no default `ease-in-out` everywhere)
+- [ ] `prefers-reduced-motion` fallback exists (static frame for 3D/shader, no autoplay for video)
+- [ ] Shader runs at 60fps on a 2021 MacBook Air or equivalent
+- [ ] 3D scene has no more than one accent material — busy = AI-slop tell
+- [ ] Voice narration has no hype words ("revolutionary", "game-changing")
+- [ ] Video is under 90s and exports a poster frame
+- [ ] Captions / transcript ship for any voice or video output
+
+## Variations
+
+- **3D portfolio piece** — see Ileana Marcut's [3D Helix portfolio](https://ileanamarcut.substack.com/p/claude-design) for the full prompt sequence; the only public worked example with prompts visible end-to-end. Useful as a calibration point: how she briefed the geometry, how she iterated the lighting, how she handed off to Three.js
+- **Shader-as-section-divider** — generate a thin (200px tall) animated band that loops; use as a section break instead of a static SVG
+- **Voice walkthrough on a deck** — pair with the [pitch-deck recipe](pitch-deck-from-readme.md): generate the deck first, then ask Claude Design to narrate the speaker notes in one pass
+- **Brand video from a static landing page** — capture your shipped landing in [web-capture-to-prototype](web-capture-to-prototype.md), then ask for a 30s motion version using the same DESIGN.md tokens
+- **Loading-state shader** — replace the standard skeleton-loader with a brand-colored shader; pairs cleanly with the system from any DESIGN.md in `/design-md/cinematic/` or `/design-md/glass/`
+
+## Common Failures
+
+- **3D scene looks like a stock asset.** Cause: brief was too generic; Claude defaulted to a "hero geometry" template. Fix: re-brief with an explicit reference URL and one constraint about geometry style ("low-poly, faceted normals, no smooth shading")
+- **Shader pegs the GPU.** Cause: nested loops in the fragment shader, or `texture()` calls in a tight loop. Fix: ask Claude to "rewrite without dynamic loops; precompute the noise field"
+- **Voice narration sounds like a podcast ad.** Cause: default TTS preset. Fix: re-prompt with explicit tone — "deliberate, no rising inflection, pauses between clauses, like a museum audio guide"
+- **Video is a slideshow with transitions.** Cause: Claude assembled stills with crossfades because no motion direction was given. Fix: re-brief with explicit camera direction ("3s slow dolly in on logo, hold 2s, cut to product detail")
+- **Generated 3D / video doesn't inherit DESIGN.md colors.** Cause: vision-model defaulted to its own palette for the new surface. Fix: paste the hex values directly into the brief — "primary surface: #1a1a1a, accent: #c96442, background: #f4f1ec, do not deviate"
+- **Burns through quota in one frontier prompt.** Cause: video and 3D are the heaviest operations Claude Design runs. Fix: budget the entire weekly allowance for one frontier piece if it's hero-grade; keep iteration in inline comments per [token budget](token-budget-claude-design.md)
+
+## References
+
+- [Anthropic — Claude Design launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) — frontier features (Voice, Video, 3D, Shaders) called out as native generation surfaces
+- [Ileana Marcut — Claude Design: Building a 3D Helix Portfolio](https://ileanamarcut.substack.com/p/claude-design) — the only public worked 3D example with prompts shown end-to-end
+- [Peter Yang — 16-min everything build](https://x.com/petergyang/status/2045527271650558383) — includes brand video generation; "creates beautiful videos, more so than slides"
+- [Ryan Mather — 7 tips for Claude Design](https://x.com/Flomerboy/status/2045162321589252458) — tip #3 (demo with video) sets the prior for motion-as-input
+- [`recipes/token-budget-claude-design.md`](token-budget-claude-design.md) — frontier surfaces cost more; budget accordingly

--- a/recipes/speaker-notes-pitch-deck.md
+++ b/recipes/speaker-notes-pitch-deck.md
@@ -1,0 +1,151 @@
+# Speaker Notes from a Generated Deck
+
+The deck is built. Now you have to deliver it. Pull the speaker notes out of a Claude Design pitch deck so you can rehearse, hand the script to a co-presenter, or feed it to a teleprompter.
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Extract clean, presenter-ready speaker notes from a Claude Design deck — usually generated alongside the slides via [pitch-deck-from-readme](pitch-deck-from-readme.md). Output: a single Markdown file you can rehearse from, edit by hand, or load into a teleprompter app.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Confirm notes exist on every slide | 1 min |
+| 2. Extract via the export menu | 2 min |
+| 3. Edit voice + add transitions | 6 min |
+| 4. Time the read-through | 8 min |
+| 5. Load into teleprompter (optional) | 3 min |
+| **Total** | **~20 min** |
+
+## Inputs
+
+- A pitch deck generated in Claude Design — ideally via the [pitch-deck-from-readme recipe](pitch-deck-from-readme.md) which already prompts for "Speaker notes on every slide — 2–3 sentences I can read aloud"
+- A target delivery surface: rehearsal-only / handoff to a co-presenter / teleprompter / printed cards
+- ~20 minutes (don't extract notes the morning of — the read-through reveals voice issues that need editing time)
+
+## Steps
+
+### 1. Confirm notes exist on every slide
+
+Open the deck. Click each slide once and check the speaker notes pane (bottom of the editor, may be collapsed). If notes are missing on any slide, prompt:
+
+```
+Add speaker notes to every slide that doesn't have them.
+2-3 sentences each, in the same voice as the existing notes.
+The notes should be readable aloud, not bullet points.
+Match the audience the deck targets ({investors / eng leadership /
+sales prospect / internal champion}).
+```
+
+Don't extract notes from a deck with gaps. The gaps will show up in the read-through and you'll have to come back for them.
+
+### 2. Extract via the export menu
+
+Two paths:
+
+- **PDF with notes** — `Export → PDF → Include speaker notes`. Produces a side-by-side: slide on left, notes on right. Best for rehearsal binders and printed cards
+- **Markdown extract** — `Export → Speaker notes only → Markdown`. Produces a single `.md` file with one section per slide (`## Slide N — {title}` heading + notes paragraph). Best for teleprompter, editing, version control
+
+If your build doesn't expose the Markdown extract option, prompt directly:
+
+```
+Export the speaker notes from every slide as a single Markdown
+document. Format:
+
+## Slide 1 — {slide title}
+
+{speaker notes verbatim}
+
+---
+
+## Slide 2 — {slide title}
+
+{speaker notes verbatim}
+
+Continue through slide 12. Include slide titles even if not on the
+slide visually. No commentary, just the notes.
+```
+
+Drop into a `.md` file in your repo (or wherever you keep delivery materials).
+
+### 3. Edit voice + add transitions
+
+Generated notes are usually 80% there. The remaining 20% is what makes the delivery work.
+
+Editing checklist:
+
+- **Cut filler** — "So basically what we're doing here is" → "We're doing this:"
+- **Add transitions between slides** — "Which brings us to" / "And the receipts:" / "One more thing:" — Claude won't generate these because each slide's notes are written in isolation
+- **Mark pauses explicitly** — `[pause]` after the punchline on slides 1, 6, and 11. The closing line of each section needs a beat
+- **Insert your own asides** — `[if asked: $750k seed at $7M post]` for likely Q&A; `[skip if running long: cut slide 9 anecdote]` for stage-time discipline
+- **Replace any hype words** — Claude sometimes drops "revolutionary" or "game-changing" into notes even if the slide copy doesn't have them. Cut on sight
+- **Re-read slide 1 and slide 12 aloud first** — these set tone and land the close. They need to feel like *you* talking, not a generated script
+
+### 4. Time the read-through
+
+Read the whole notes file aloud at presentation pace. Use a stopwatch. Target:
+
+| Deck length | Note read-time target |
+|---|---|
+| 12-slide pitch | 8–10 min spoken |
+| Conference talk (20–30 slides) | 18–25 min spoken |
+| Internal review (8 slides) | 5–7 min spoken |
+
+If you're way over, the notes are too long — cut to the bones, leave only the load-bearing sentences. If you're way under, the notes are too tight — add the proof points and asides that make the delivery breathe.
+
+### 5. Load into teleprompter (optional)
+
+If you're using a teleprompter app (Teleprompter+ on iPad, PromptSmart on iOS, OBS Studio scenes), the Markdown extract pastes cleanly. Most teleprompters strip Markdown and render as scrolling plain text.
+
+Settings to check:
+
+- **Scroll speed** — calibrate against your read-through time
+- **Mirror mode** — required if reading off a teleprompter glass
+- **Font size** — usually 36–48pt for stage; 24pt for screen-share rehearsal
+- **Auto-advance per slide** — most teleprompters can sync slide advance to your scroll position
+
+Print a backup PDF (with notes) regardless. Teleprompters fail.
+
+## Quality Checks
+
+- [ ] Every slide has notes — no gaps
+- [ ] Notes read aloud sound like *you*, not a generated voice
+- [ ] Transitions between slides exist where the slide topic shifts
+- [ ] Pauses marked on slides 1, the section break, and the close
+- [ ] No hype words ("revolutionary", "game-changing", "seamless")
+- [ ] Total read-through time matches your stage allotment ±15%
+- [ ] Q&A asides drafted for the obvious questions
+- [ ] Slide 11 (the ask) reads as a specific ask, not "let's chat"
+- [ ] Backup PDF printed (or PDF on your phone) — teleprompters fail
+- [ ] Co-presenter (if any) has the notes file too
+
+## Variations
+
+- **Co-presenter handoff** — split the notes file by speaker. Use bracket annotations: `[ALEX]` and `[YOU]` per paragraph. Re-export so each presenter has their lines highlighted
+- **Conference-talk variant** — extend each slide's notes from 2–3 sentences to 4–6, since you have more stage time per slide. Re-prompt: "expand the notes on each slide to 4–6 sentences, presenter pace"
+- **Demo-script variant** — for slides that include a live demo, replace notes with a step-by-step demo script: "Click X. Highlight Y. Say: 'this is the part where Z.'" Prevents on-stage fumbling
+- **Internal-review variant** — strip the notes to single sentences. The reader is following along with the deck, not listening to you read; brevity matters more than cadence
+- **Voice-narrated version** — feed the notes to the [frontier voice surface](frontier-3d-shaders.md) for an audio walkthrough; pair with the deck for async sharing
+- **One-pager from notes** — ask Claude Design to "compress these notes into a 500-word one-pager that captures the same arc"; useful as a leave-behind
+
+## Common Failures
+
+- **Notes read like marketing copy.** Cause: deck was prompted with hype-word language; notes inherited it. Fix: re-prompt notes with "rewrite in spoken voice — direct, no superlatives, the voice a founder uses talking to a peer."
+- **Every slide's notes start with "So,".** Cause: TTS-style filler from generation. Fix: find-and-replace `^So, ` → empty string in your editor.
+- **Notes don't transition between slides.** Cause: each slide generated in isolation. Fix: add transitions yourself in step 3 — Claude won't do this without explicit slide-pair context.
+- **Slide 11 (the ask) is vague.** Cause: README didn't have a specific ask, so notes hedged. Fix: hand-write slide 11's notes; this is the most important paragraph of the deck.
+- **Read-through is 50% over the time budget.** Cause: notes are too long for the slide count. Fix: cut to the load-bearing sentences; you can add back during rehearsal if you have time.
+- **Teleprompter scrolls past you mid-slide.** Cause: scroll speed calibrated to silent-read pace, not spoken pace. Fix: re-calibrate against a stopwatched read-through; spoken is ~150 wpm, silent-read is ~250 wpm.
+- **Lost the notes file because it was only in Claude Design.** Cause: didn't export. Fix: always export to a `.md` in your repo as soon as the deck is final. Don't trust the canvas to be the source of truth for delivery materials.
+
+## References
+
+- [`recipes/pitch-deck-from-readme.md`](pitch-deck-from-readme.md) — the upstream recipe; the deck-generation prompt explicitly asks for "Speaker notes on every slide — 2–3 sentences I can read aloud"
+- [Linas Beliūnas — Founder's Playbook](https://linas.substack.com/p/claude-design-founders-playbook) — workflow #5 covers deck delivery prep
+- [Lenny's Newsletter — What Claude Design is actually good for](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good) — slide-deck output ranked as one of the strongest surfaces; speaker-notes export covered
+- [Adweek — Anthropic debuts Claude Design for marketing assets, decks, UIs](https://www.adweek.com/media/anthropic-debuts-claude-design-for-building-marketing-assets-decks-and-uis/) — decks as a primary launch positioning surface
+- [getpushtoprod — Everything You Need to Know](https://getpushtoprod.substack.com/p/everything-you-need-to-know-about) — Slide template workflow with hand-off detail

--- a/recipes/tweaks-panel-sidebar.md
+++ b/recipes/tweaks-panel-sidebar.md
@@ -1,0 +1,144 @@
+# Tweaks Panel — No-Regen Iteration
+
+The Tweaks panel is the cheapest surface in Claude Design. Reorder sections, swap variants, retune spacing — all without re-prompting and without burning vision tokens. This recipe covers when to use it (and when not to).
+
+<img src="../assets/tags/curated.svg" alt="curated"> <img src="../assets/tags/new.svg" alt="new">
+
+---
+
+## Goal
+
+Use the Tweaks sidebar for layout-level edits that would otherwise cost a chat round. Comment on elements for component-level edits. Reserve chat for structural or conceptual changes. The result: weekly allowance lasts 3–5x longer.
+
+## Time
+
+| Step | Wall-clock |
+|---|---|
+| 1. Generate the first artifact | (skip — assume already done) |
+| 2. Open Tweaks panel | 5 sec |
+| 3. Reorder sections | 1–2 min |
+| 4. Swap variants on cards / heroes | 1–2 min |
+| 5. Tune spacing + density tokens | 2–3 min |
+| 6. Commit and continue | — |
+| **Total per iteration** | **~5 min, ~zero tokens** |
+
+## Inputs
+
+- A generated artifact in Claude Design (page, deck, prototype) you want to refine
+- Knowledge of which knobs the Tweaks panel exposes for that artifact type
+- The mental model below: which edit goes where
+
+## The three iteration surfaces
+
+There are three ways to change a Claude Design artifact, and they cost wildly different amounts:
+
+| Surface | Use for | Token cost |
+|---|---|---|
+| **Tweaks panel** | Layout: reorder, swap variants, density, spacing scale, accent intensity | ~0 (no LLM call) |
+| **Inline comments** | Component-level edits: "this card needs more padding," "wrong icon" | Low (local re-render) |
+| **Chat re-prompt** | Structural changes: new section, different page intent, conceptual pivot | High (full vision pass) |
+
+The mistake every new user makes: chat-prompting every change. Per Austin Lau (Anthropic), the [Tweaks panel demo](https://x.com/helloitsaustin/status/2045176910569980318) shows this explicitly — section reordering and variant swaps happen in the sidebar, not the chat.
+
+## Steps
+
+### 1. Open the Tweaks panel
+
+In any generated artifact, look for the **Tweaks** sidebar (right edge of the canvas in current preview build; collapsed by default on narrow viewports). Knobs typically include:
+
+- **Section order** — drag handles to reorder hero / features / pricing / footer
+- **Section variant** — swap "three-column features" for "two-column with image"
+- **Density** — compact / comfortable / spacious
+- **Spacing scale** — tighten or loosen the global modular scale
+- **Accent intensity** — how often the accent color appears (subtle / standard / loud)
+- **Component variants** — for hero, card, nav: pick from 2–4 pre-derived variants from your DESIGN.md
+
+The exact knob set varies by artifact type. Decks expose slide-template knobs; prototypes expose nav-pattern knobs; landing pages expose section-order + variant.
+
+### 2. Reorder sections
+
+Most common no-regen win. Drag a section in the Tweaks panel — Claude reorders without re-rendering the section content. Hero stays the hero, just appears earlier or later.
+
+Use this when:
+
+- Your social-proof section should come *before* the feature grid (common edit)
+- The pricing teaser belongs above the footer-CTA, not below
+- You want to A/B-style two layouts: drag, screenshot, drag back, screenshot
+
+Do **not** use chat for this. Chat will regenerate every section.
+
+### 3. Swap variants
+
+Each section type has 2–4 variants pre-derived from your DESIGN.md tokens. The panel shows them as thumbnails. Click to swap — same content, different layout.
+
+Examples:
+
+- Hero: "type-only" / "split with image" / "centered with screenshot" / "video background"
+- Features: "three-card grid" / "two-column with icon" / "tabbed list" / "comparison table"
+- Pricing: "three-tier" / "single-CTA" / "feature matrix" / "calculator widget"
+
+If the variant you want isn't in the panel, *that's* a chat re-prompt (you're asking for a new variant Claude hasn't pre-derived). Otherwise, never chat for a variant swap.
+
+### 4. Tune spacing + density
+
+The density slider quietly does a lot. Compact = tighter padding, smaller type scale, denser cards. Spacious = the opposite. Most "this looks too crowded" or "this feels empty" complaints fix here.
+
+Watch the meter: density and spacing changes are zero-token because they're CSS variable tweaks, not regenerations. You can scrub them live.
+
+### 5. Commit and continue
+
+Once the layout is right, lock it via the panel and move to inline comments for component-level edits. Save chat for the next structural change.
+
+## When to use which surface
+
+A practical decision tree:
+
+```
+Did the *content* change? → chat re-prompt (expensive but necessary)
+Did a *new section type* appear? → chat re-prompt
+Did the page *intent* change? → chat re-prompt
+
+Did a section *move*? → Tweaks panel (free)
+Did a variant *swap*? → Tweaks panel (free)
+Did density / spacing *shift*? → Tweaks panel (free)
+
+Did a single *component* need fixing? → inline comment (cheap)
+Did a button copy / icon / label change? → inline comment (cheap)
+Did one card need more padding? → inline comment (cheap)
+```
+
+Print this near your monitor for a week. After that you'll have it internalized.
+
+## Quality Checks
+
+- [ ] Section reorder happened in Tweaks, not chat
+- [ ] Variant swaps happened in Tweaks, not chat
+- [ ] Density / spacing tuned via slider, not chat
+- [ ] Inline comments used for any single-component fix
+- [ ] Chat reserved for structural / conceptual / new-section changes
+- [ ] No regeneration triggered for a one-color tweak (use inline comment + the color picker)
+
+## Variations
+
+- **Pre-meeting iteration** — before showing a stakeholder, do all reorder + variant swaps in Tweaks. Zero tokens, real-feeling iteration.
+- **A/B layout exploration** — drag a section, screenshot, drag back, screenshot. Two PNGs to compare without spending vision tokens twice.
+- **Density-only audit** — scrub from compact → spacious watching one section. Find the right setting for your DESIGN.md, then lock it.
+- **Variant exhaustion** — click through every variant on a section to see what Claude pre-derived. Sometimes the best layout is one you didn't ask for.
+- **Sidebar-only workshop** — challenge yourself to refine an artifact for 30 minutes using only the Tweaks panel. You'll discover what the panel actually covers.
+
+## Common Failures
+
+- **You kept chatting and burned the weekly allowance.** Cause: muscle memory from ChatGPT — type to make changes. Fix: print the decision tree above; physically tape it next to your monitor for a week.
+- **The variant you want isn't in the panel.** Cause: Claude only pre-derives 2–4 variants per section. Fix: chat-prompt for it ("add a fourth hero variant: video background with mute toggle"); after Claude generates it, it'll appear in the panel for future swaps.
+- **Reordering broke the visual rhythm.** Cause: a section depended on its neighbor (e.g., gradient bleed across two sections). Fix: chat-prompt to "re-derive section transitions after reordering."
+- **Density slider made type illegible.** Cause: pushed compact too far for body text. Fix: snap back one step; or comment inline "increase body type scale by one step but keep padding."
+- **Tweaks panel doesn't appear on mobile preview.** Cause: it collapses on narrow viewports by design. Fix: switch to desktop preview to access it; tweaks apply across breakpoints.
+- **You can't find Tweaks.** Cause: it's the right-edge sidebar; some plans hide it behind a feature-flag in early preview. Fix: check `claude.ai/design → settings`; if it's missing, your workspace hasn't been opted into the panel yet.
+
+## References
+
+- [Austin Lau (Anthropic) — Tweaks panel demo](https://x.com/helloitsaustin/status/2045176910569980318) — the source of the reorder + variant-swap workflow shown end-to-end
+- [Ryan Mather — 7 tips for Claude Design](https://x.com/Flomerboy/status/2045162321589252458) — tip #2 ("Comment, don't chat") is the inline-comment half of the same model
+- [`recipes/comment-paste-workaround.md`](comment-paste-workaround.md) — the inline-comment workaround for component-level edits when full chat re-prompts cost too much
+- [`recipes/token-budget-claude-design.md`](token-budget-claude-design.md) — the broader spend model; Tweaks + comments are the two zero/low-cost surfaces
+- [Anthropic — Claude Design subscription usage and pricing](https://support.claude.com/en/articles/14667344-claude-design-subscription-usage-and-pricing) — quota math; weekly allowance applies to chat prompts, not Tweaks


### PR DESCRIPTION
Four new recipes in `/recipes/`, wired into the README's Workflows & Recipes list as items 14–17. Closes the gap between the existing landing-page / pitch-deck recipes and Claude Design's frontier surfaces + iteration mechanics.

## Recipes

### 14. `recipes/frontier-3d-shaders.md`
Building 3D, shaders, voice, and video features inside Claude Design. Covers surface picker (3D vs shader vs voice vs video), constraint blocks per surface, performance budgets, and inline-comment iteration patterns specific to frontier output.

**Sources cited:**
- [Anthropic — Claude Design launch post](https://www.anthropic.com/news/claude-design-anthropic-labs) — Voice / Video / 3D / Shaders called out as native generation surfaces
- [Ileana Marcut — Claude Design: Building a 3D Helix Portfolio](https://ileanamarcut.substack.com/p/claude-design) — only public worked 3D example with prompts shown end-to-end

### 15. `recipes/tweaks-panel-sidebar.md`
Using the Tweaks sidebar for no-regen iteration: reorder sections, swap variants, tune density. Decision tree for *Tweaks vs comments vs chat* per edit type. The big quota-saver most users miss.

**Source cited:**
- [Austin Lau (Anthropic) — Tweaks panel demo](https://x.com/helloitsaustin/status/2045176910569980318)

Best practice surfaced: **Tweaks for layout, comments for component, chat for structural changes.**

### 16. `recipes/comment-paste-workaround.md`
The community-discovered move: when a chat re-prompt would cost too much weekly allowance, paste the would-be prompt as an inline comment on the element instead. Same precision, fraction of the tokens.

**Sources cited:**
- [MacStories — Hands-On with Anthropic Labs' Claude Design Preview](https://www.macstories.net/stories/hands-on-with-anthropic-labs-claude-design-preview/) — the "comment-on-element covers 95% of what's needed" observation
- [Ryan Mather — 7 tips for Claude Design](https://x.com/Flomerboy/status/2045162321589252458) — tip #2 ("Comment, don't chat")

### 17. `recipes/speaker-notes-pitch-deck.md`
Extract presenter-ready speaker notes from a Claude Design deck. Pairs with the existing `pitch-deck-from-readme` recipe — that one builds the deck, this one prepares the delivery.

**Sources cited:**
- [`recipes/pitch-deck-from-readme.md`](recipes/pitch-deck-from-readme.md) (upstream)
- [Linas Beliūnas — Founder's Playbook](https://linas.substack.com/p/claude-design-founders-playbook)
- [Lenny's Newsletter — What Claude Design is actually good for](https://www.lennysnewsletter.com/p/what-claude-design-is-actually-good)
- [Adweek — Anthropic debuts Claude Design for marketing assets, decks, UIs](https://www.adweek.com/media/anthropic-debuts-claude-design-for-building-marketing-assets-decks-and-uis/)

## README change

Single edit to the numbered list in `## Workflows & Recipes` — appended items 14, 15, 16, 17. No changes to banner, hero, gallery, anti-slop, family tables, comparisons, community takes, or FAQ.

## Conventions followed

- Each recipe matches `recipes/landing-page-20-min.md` structure: Goal · Time table · Inputs · Steps · Quality Checks · Variations · Common Failures · References
- Tag badges via `../assets/tags/curated.svg` + `../assets/tags/new.svg` (or `community.svg` for the comment-paste workaround)
- Hard URLs for every source citation
- Cross-links to existing recipes (`token-budget-claude-design`, `pitch-deck-from-readme`) where the workflows compose