### PR TITLE
add: 4 auto/luxury DESIGN.md (BMW, Ferrari, Lamborghini, Renault)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Submit more: handle, verbatim quote ≤280 chars, tweet URL, engagement numbers.
 
 Not sorted by industry. Sorted by **visual character** — because that's how designers actually pick. Each family links to (1) a working `DESIGN.md` in `/design-md/<family>/`, (2) canonical external references, (3) a one-line swatch + type spec so you can eyeball fit before cloning.
 
-**Shipped samples in this repo:** [warm/claude.md](design-md/warm/claude.md) · [warm/mercury.md](design-md/warm/mercury.md) · [terminal/ollama.md](design-md/terminal/ollama.md) · [terminal/warp.md](design-md/terminal/warp.md) · [editorial/linear.md](design-md/editorial/linear.md) · [editorial/vercel.md](design-md/editorial/vercel.md) · [data-dense/clickhouse.md](design-md/data-dense/clickhouse.md) · [data-dense/posthog.md](design-md/data-dense/posthog.md) · [data-dense/datadog.md](design-md/data-dense/datadog.md) · [cinematic/runway.md](design-md/cinematic/runway.md) · [cinematic/tavus.md](design-md/cinematic/tavus.md) · [cinematic/cohere.md](design-md/cinematic/cohere.md) · [playful/figma.md](design-md/playful/figma.md) · [playful/canva.md](design-md/playful/canva.md) · [glass/arc.md](design-md/glass/arc.md) · [glass/apple.md](design-md/glass/apple.md) · [brutalist/the-verge.md](design-md/brutalist/the-verge.md) · [indie/granola.md](design-md/indie/granola.md) · [remix/linear-x-claude.md](design-md/remix/linear-x-claude.md) · [remix/warp-x-sentry.md](design-md/remix/warp-x-sentry.md) · [remix/stripe-x-a24.md](design-md/remix/stripe-x-a24.md)
+**Shipped samples in this repo:** [warm/claude.md](design-md/warm/claude.md) · [warm/mercury.md](design-md/warm/mercury.md) · [terminal/ollama.md](design-md/terminal/ollama.md) · [terminal/warp.md](design-md/terminal/warp.md) · [editorial/linear.md](design-md/editorial/linear.md) · [editorial/vercel.md](design-md/editorial/vercel.md) · [data-dense/clickhouse.md](design-md/data-dense/clickhouse.md) · [data-dense/posthog.md](design-md/data-dense/posthog.md) · [data-dense/datadog.md](design-md/data-dense/datadog.md) · [cinematic/runway.md](design-md/cinematic/runway.md) · [cinematic/tavus.md](design-md/cinematic/tavus.md) · [cinematic/cohere.md](design-md/cinematic/cohere.md) · [cinematic/bmw.md](design-md/cinematic/bmw.md) · [cinematic/ferrari.md](design-md/cinematic/ferrari.md) · [cinematic/lamborghini.md](design-md/cinematic/lamborghini.md) · [cinematic/renault.md](design-md/cinematic/renault.md) · [playful/figma.md](design-md/playful/figma.md) · [playful/canva.md](design-md/playful/canva.md) · [glass/arc.md](design-md/glass/arc.md) · [glass/apple.md](design-md/glass/apple.md) · [brutalist/the-verge.md](design-md/brutalist/the-verge.md) · [indie/granola.md](design-md/indie/granola.md) · [remix/linear-x-claude.md](design-md/remix/linear-x-claude.md) · [remix/warp-x-sentry.md](design-md/remix/warp-x-sentry.md) · [remix/stripe-x-a24.md](design-md/remix/stripe-x-a24.md)
 
 ### 1. Editorial Minimalism
 
@@ -441,6 +441,10 @@ Film-grade gradients, oversized type, motion-forward, media-heavy hero. Built fo
 | ElevenLabs | `#0a0a0a / electric blue / wave motifs` | Inter | [elevenlabs.io](https://elevenlabs.io) |
 | Minimax | `#000 / neon lime on charcoal` | Custom + mono | [minimax.ai](https://minimax.ai) |
 | Midjourney | `#000 / earth tones + lilac` | Editorial serif | [midjourney.com](https://midjourney.com) |
+| BMW | `#fff / #1c69d4 corporate blue / M-gradient` | BMW Type Next Web + Helvetica Neue | [bmw.com](https://bmw.com) |
+| Ferrari | `#000 / #fff / #eb2323 Rosso Corsa` | FerrariSans | [ferrari.com](https://ferrari.com) |
+| Lamborghini | `#000 / #ffc000 warm gold / hex motif` | LamboType + Roboto | [lamborghini.com](https://lamborghini.com) |
+| Renault | `#fff / aurora yellow→magenta→cyan / #efdf00 + #e91630` | NouvelR | [renault.fr](https://renault.fr) |
 
 ### 6. Playful Color
 

--- a/design-md/cinematic/bmw.md
+++ b/design-md/cinematic/bmw.md
@@ -1,0 +1,96 @@
+# BMW — Editorial Performance Blue
+
+Reference DESIGN.md for luxury automotive editorial that needs to feel engineered. White slabs, full-bleed performance photography, BMW corporate blue rising into a deeper blue at active states, restrained Helvetica-grade typography.
+
+## 1. Visual Theme & Atmosphere
+
+Editorial automotive. The page is a magazine: oversized photo plates of the car, clean white margins, narrow blue keyline rules. Headlines are short and committed. Blue is the only chromatic note — every other surface is paper-white or near-black. Reads like a Munich brochure that learned to scroll.
+
+Mood: precise, premium, engineered, quietly confident.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #ffffff
+--bg-alt:          #f6f6f6   /* spec sheet, secondary slab */
+--surface:         #ffffff
+--ink:             #262626   /* body text, headlines on light */
+--ink-muted:       #6b6b6b
+--ink-dim:         #a8a8a8
+--bg-inverse:      #111111   /* M Performance dark slab */
+--text-on-dark:    #ffffff
+--accent:          #1c69d4   /* BMW corporate blue, primary CTA */
+--accent-hover:    #0653b6   /* deeper marine on hover, focus, link */
+--m-gradient:      linear-gradient(90deg, #2e9bd6 0%, #1c69d4 50%, #0653b6 100%)
+--border:          #e5e5e5
+--rule:            #1c69d4
+```
+
+One blue, one neutral pair. The M-style gradient is reserved for performance moments — never on body or buttons.
+
+## 3. Typography Rules
+
+- **Display + headings:** `BMW Type Next Web`, fallback `Helvetica Neue`, `Helvetica`, `Arial`, `sans-serif`. Weight 400 for editorial, 700 for vehicle nameplates. Tight tracking at 48px+.
+- **Body + UI:** same stack, weight 400, 16–18px, 1.5 line-height.
+- **Labels + spec rows:** uppercase, tracked 8%, 12–13px, ink-muted.
+
+Scale: 12 / 14 / 16 / 20 / 28 / 36 / 48 / 64 / 96. Restraint is the point — brochures don't shout.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: `--accent` fill, white text, radius 3px, padding 12/24, weight 500.
+- Secondary: transparent, 1px ink border, ink text, 3px radius.
+- Hover: fill shifts to `--accent-hover`. No scale, no glow.
+
+**Cards / vehicle tiles**
+- White surface, 1px `--border`, radius 3px. Photo top, two-line title, one-line spec, blue inline link.
+- Hover: border shifts to `--accent`. Shadow stays off.
+
+**Inputs**
+- White fill, 1px border, 3px radius. Focus: 2px `--accent` ring, no offset.
+
+**Nav**
+- Fixed top, white fill, 1px bottom border. Logo left, model groups center, account/build right. Active link gets a 2px `--accent` underline.
+
+**Hero photo plate**
+- Full-bleed vehicle photograph, 70–90vh. Headline overlaid bottom-left in white, 64–96px. CTA below in primary blue.
+
+## 5. Layout Principles
+
+- 1440px max, 24px gutter, 12 column.
+- 8px base. 8 / 16 / 24 / 32 / 48 / 80 / 120.
+- Alternate full-bleed hero, white spec slab, `--bg-alt` comparison slab.
+- Section breaks at 96–120px on desktop. Whitespace flanks the photograph; never crop the car.
+
+## 6. Depth & Elevation
+
+Almost flat. Depth comes from photographic contrast, not chrome. Allowed: 1px `--border` on cards, 2px `--accent` keyline at section breaks. Shadows reserved for floating spec sheets only — `0 8px 24px rgba(0, 0, 0, 0.08)`. No glows, no neumorphism.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Lead with full-bleed vehicle photography at the fold.
+- Hold to one blue. Use the M-gradient once, on a single performance moment.
+- Pair short editorial headlines with tracked uppercase labels for specs.
+- Keep buttons binary: blue primary or ghost. Sharp 3px corners only.
+
+**Don't**
+- Apply the M-gradient to buttons, links, or body type.
+- Add a second accent color (red, gold, green) — that's a competitor brand.
+- Round corners past 4px or pill anything — automotive is engineered, not playful.
+- Drop the photograph for stock illustration or hero CGI.
+- Use heavy shadows or backdrop blur on nav.
+
+## 8. Responsive Behavior
+
+- Hero headline scales 96 → 36 on mobile, retains weight 400.
+- Vehicle photo retains full bleed; CTA stacks below headline.
+- Nav collapses to white hamburger below 1024px; model groups fold into a single sheet.
+- 12-column grid reflows to single column below 768px; 64px section rhythm.
+
+## 9. Agent Prompt Guide
+
+Bias: paper-white canvas, full-bleed automotive photography, BMW Type Next Web headlines, single corporate blue (`#1c69d4`) on CTAs, sharp 3px radii, tracked uppercase spec labels, restrained editorial rhythm, M-gradient used once per page maximum.
+
+Reject: dark-mode default, multi-color accents, pill buttons, drop shadows on hero plates, gradient-filled body type, stock illustration replacing the vehicle photo, glassmorphism, oversized rounded corners.

--- a/design-md/cinematic/ferrari.md
+++ b/design-md/cinematic/ferrari.md
@@ -1,0 +1,99 @@
+# Ferrari — Chiaroscuro Rosso Corsa
+
+Reference DESIGN.md for performance brands that need to feel theatrical. High-contrast black-and-white frames cut by Rosso Corsa red, sharp 0-radius components, FerrariSans across the entire page, photography that treats the car as sculpture.
+
+## 1. Visual Theme & Atmosphere
+
+Cinematic chiaroscuro. The page alternates between a deep ink stage and a paper-white gallery, with Rosso Corsa appearing once per section as a single decisive note — a CTA, a rule, a numeral. Photography is high-contrast: car against black sky, paddock light, Maranello tarmac. Every component is a sharp rectangle. Italian editorial discipline meets Formula 1 timing.
+
+Mood: theatrical, decisive, hand-built, fast.
+
+## 2. Color Palette & Roles
+
+```
+--bg-light:        #ffffff
+--bg-dark:         #000000   /* full-bleed dark slabs, hero */
+--bg-alt:          #f4f4f4   /* spec rail, paddock light */
+--text-on-light:   #000000
+--text-on-dark:    #ffffff
+--text-muted:      #6a6a6a
+--accent:          #eb2323   /* Rosso Corsa, primary CTA + rule */
+--accent-hover:    #c81a1a
+--accent-bright:   #ff0000   /* link, focus, livery moments */
+--support-yellow:  #f6e500   /* Modena yellow, race-livery accent only */
+--border:          #1a1a1a
+--rule:            #eb2323
+```
+
+Rule: red appears once per visual frame. Never two reds touching. Yellow is reserved for racing-content slabs and never sits in the same hero as a CTA.
+
+## 3. Typography Rules
+
+- **Display + headings:** `FerrariSans`, fallback `Helvetica`, `Arial`, `sans-serif`. Weight 700 for nameplates, weight 500 for editorial heads. Tracked −1% above 48px.
+- **Body + UI:** FerrariSans regular, 13–16px body, 1.5 line-height.
+- **Numerals (lap times, displacement, top speed):** tabular, weight 700, oversized — 64–140px.
+- **Labels:** uppercase, tracked 10%, 11–12px.
+
+Scale: 11 / 13 / 16 / 20 / 26 / 36 / 56 / 88 / 140.
+
+Single typeface. The contrast is black/white/red — not type families.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: `--accent` fill, white text, radius 0, padding 14/28, weight 700, uppercase, tracked 6%.
+- Secondary on light: transparent, 1px ink border, ink text, sharp rectangle.
+- Ghost on dark: transparent, 1px white border, white text.
+- Hover: fill shifts to `--accent-hover` instantly. No transition softening.
+
+**Cards / model tiles**
+- No card chrome on hero. Full-bleed photo on `--bg-dark` with overlaid label bottom-left.
+- Spec cards on light: white surface, 1px `--border` hairline above and below only — no left/right border. Radius 0.
+
+**Inputs**
+- Sharp rectangle, 1px ink border, 12/16 padding, radius 0. Focus: 2px `--accent` outline, no offset.
+
+**Nav**
+- Fixed top, transparent over hero, snaps to ink fill on scroll. White wordmark, uppercase nav links, red active underline 2px.
+
+**Hero**
+- Full-bleed dark slab, vehicle photo right-aligned 60% width, headline left in white at 88–140px, single `--accent` CTA below.
+
+## 5. Layout Principles
+
+- 1320px max content, full-bleed photo plates, 24px gutter, 12 column.
+- 8px base. 8 / 16 / 24 / 32 / 48 / 80 / 120 / 160.
+- Alternate dark hero → white spec → dark dyno-numerals → white configurator.
+- Asymmetric splits (60/40 photo + numeral block) over symmetric grids.
+
+## 6. Depth & Elevation
+
+Flat, theatrical. Depth from contrast, not shadow. Allowed: 1px hairline above/below spec rows. Forbidden: drop shadows on cards, glow effects, beveled edges, layered translucency.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Use one Rosso Corsa moment per visual frame: CTA, rule, or oversized numeral.
+- Oversize lap times and displacement numerals to 88–140px.
+- Alternate dark and light slabs aggressively — chiaroscuro is the brand.
+- Keep every corner at radius 0.
+
+**Don't**
+- Pair red and yellow in the same hero. Yellow is racing-only.
+- Round any corner. No pill buttons, ever.
+- Add drop shadows, glows, or backdrop blur.
+- Mix in a second typeface — FerrariSans does everything.
+- Use lifestyle stock photography. The car is the subject, always.
+
+## 8. Responsive Behavior
+
+- Hero headline scales 140 → 48 on mobile, retains weight 500.
+- Vehicle photo stacks above headline below 768px; dark slab retains full bleed.
+- Nav collapses to ink hamburger; uppercase links stay tracked.
+- Oversized numerals scale 140 → 64 but never thin out — weight 700 holds.
+
+## 9. Agent Prompt Guide
+
+Bias: alternating black/white full-bleed slabs, FerrariSans single-family typography, oversized lap-time numerals (88–140px), Rosso Corsa `#eb2323` used once per frame as CTA or rule, sharp 0-radius components, uppercase tracked nav.
+
+Reject: rounded corners, drop shadows, multi-typeface mixing, red and yellow in the same hero, pastel palettes, lifestyle stock photography, gradient buttons, glassmorphism, sidebar-heavy layouts.

--- a/design-md/cinematic/lamborghini.md
+++ b/design-md/cinematic/lamborghini.md
@@ -1,0 +1,105 @@
+# Lamborghini — Black Cathedral Gold
+
+Reference DESIGN.md for hyper-luxury that needs to feel forged. True-black canvas, oversized LamboType nameplates at 120px+, hexagonal angle motifs, single warm-gold accent for primary actions, photography lit like a vault.
+
+## 1. Visual Theme & Atmosphere
+
+Black cathedral. The page is dark architecture — true `#000000` canvas, vehicles lit from below like sculpture, type carved into the screen at 120px. Geometry is angular: hex motifs in dividers, sharp 0-radius components, no soft edges anywhere. Gold appears as a single decisive accent on CTAs and active states. Reads like a Sant'Agata showroom at night.
+
+Mood: forged, dramatic, exclusive, mechanical.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #000000   /* true black, default canvas */
+--bg-alt:          #0a0a0a   /* spec slab, secondary surface */
+--surface:         #141414   /* card, configurator panel */
+--text:            #ffffff
+--text-muted:      #b8b8b8
+--text-dim:        #6a6a6a
+--accent:          #ffc000   /* warm gold, primary CTA */
+--accent-hover:    #ffce3e   /* lifted gold on hover */
+--accent-deep:     #917300   /* engraved gold, rules + active state */
+--border:          #1f1f1f
+--rule:            #2a2a2a
+--hex-stroke:      #2a2a2a   /* hex grid motif */
+```
+
+One gold, three depths of black. No second accent. Color restraint is the luxury signal.
+
+## 3. Typography Rules
+
+- **Display + nameplates:** `LamboType`, fallback `Roboto`, `Helvetica Neue`, `Arial`. Weight 700, slight italic on model names. Tight tracking −2%. Used at 64–168px.
+- **Body + UI:** `Roboto`, weight 400, 16–18px body, 1.55 line-height.
+- **Labels + spec rows:** uppercase, tracked 12%, 11–12px, `--text-muted`.
+- **Numerals (top speed, 0-100, output):** tabular, weight 700, paired with small unit labels.
+
+Scale: 11 / 14 / 16 / 20 / 28 / 40 / 64 / 96 / 120 / 168.
+
+Headlines go enormous — 120px is the floor for nameplates, not the ceiling.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: `--accent` fill, black text, radius 0, padding 14/28, weight 700, uppercase, tracked 8%.
+- Secondary: transparent, 1px white border, white text, radius 0.
+- Ghost: transparent, white text, no border, underline on hover.
+- Hover: primary lifts to `--accent-hover`; secondary fills white-on-black inversion. No scale.
+
+**Cards / model tiles**
+- `--surface` fill, 1px `--border`, radius 0. Photo top, model name centered in LamboType at 40px, spec strip below.
+- Hover: border shifts to `--accent-deep`, no shadow.
+
+**Inputs**
+- `--bg-alt` fill, 1px `--border`, radius 0, 14/16 padding. Focus: 2px `--accent` ring, no offset.
+
+**Nav**
+- Fixed top, transparent over hero, fills to `--bg` on scroll. White wordmark, uppercase tracked links, gold active underline 2px.
+
+**Hex motif**
+- Used sparingly: section dividers as a single 1px hex outline at the seam, never as repeating pattern wallpaper.
+
+**Hero**
+- Full-bleed black slab, vehicle photo center-stage, nameplate overlaid at 120–168px in white, single gold CTA bottom-center.
+
+## 5. Layout Principles
+
+- 1440px max, 24px gutter, 12 column.
+- 8px base. 8 / 16 / 24 / 32 / 48 / 80 / 120 / 160.
+- Alternate full-bleed black hero → `--bg-alt` spec slab → black configurator.
+- Centered compositions over asymmetric — the car is on a plinth.
+- Section breaks at 120–160px on desktop.
+
+## 6. Depth & Elevation
+
+Architectural, never soft. Depth from light direction in photography and tonal step between `#000` / `#0a0a0a` / `#141414`. Allowed: 1px hex divider, 1px border on cards. Forbidden: drop shadows, glows, backdrop blur, neumorphism, gradient fills.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Hold true `#000000` as the canvas — not `#0a0a` and not `#111`.
+- Push nameplates to 120–168px; let them dominate the fold.
+- Keep gold as the only chromatic note. One gold CTA per section.
+- Use sharp 0-radius corners on every component.
+- Keep the hex motif as a single outline at section seams, not a repeating pattern.
+
+**Don't**
+- Switch to off-black or charcoal. The true black is the differentiator.
+- Add a second accent (red, blue, white-gold variants).
+- Round corners or pill buttons.
+- Apply drop shadows, glows, or beveled chrome.
+- Use repeating hex wallpaper — that reads as gaming, not luxury.
+- Mix in a serif typeface for "elegance".
+
+## 8. Responsive Behavior
+
+- Nameplate scales 168 → 56 on mobile, retains weight 700.
+- Vehicle photo stacks above nameplate below 768px; black slab retains full bleed.
+- Nav collapses to gold-on-black hamburger; uppercase tracked links stay.
+- Spec strips reflow to single column; gold CTA stays full-width below 480px.
+
+## 9. Agent Prompt Guide
+
+Bias: true-black `#000000` canvas, oversized LamboType nameplates (120–168px), single warm-gold accent (`#ffc000`) on CTAs, sharp 0-radius components, hex motifs as 1px section seams, vehicle photographed as plinth-lit sculpture, uppercase tracked nav, three-tone black depth (`#000` / `#0a0a` / `#141414`).
+
+Reject: charcoal or off-black backgrounds, secondary accent colors, rounded corners, drop shadows, glow rings, backdrop blur, repeating hex wallpaper, serif type for elegance, lifestyle photography, pill buttons, gradient backgrounds.

--- a/design-md/cinematic/renault.md
+++ b/design-md/cinematic/renault.md
@@ -1,0 +1,107 @@
+# Renault — Aurora Pop Geometric
+
+Reference DESIGN.md for European mobility brands that need to feel modern and warm at once. Paper-white canvas with full-bleed aurora gradients (yellow → magenta → cyan), the diamond logomark as primary geometric anchor, NouvelR across the page, restrained 4px corner softening on inputs only.
+
+## 1. Visual Theme & Atmosphere
+
+Aurora pop. The page is mostly paper, then drops into full-bleed aurora panels — yellow easing into magenta into cyan — that echo the Renault diamond logomark. NouvelR carries every word; geometry leans into the diamond shape on dividers and section anchors. Vehicle photography is sun-lit, color-rich, never moody.
+
+Mood: optimistic, European, current, electric.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #ffffff
+--bg-alt:          #f4f4f4
+--surface:         #ffffff
+--ink:             #000000
+--ink-muted:       #5a5a5a
+--ink-dim:         #9a9a9a
+--accent-yellow:   #efdf00   /* primary brand mark, CTA fill */
+--accent-red:      #e91630   /* secondary CTA, inline link */
+--accent-red-hover: #c41229
+--accent-blue:     #1885d1   /* tertiary, electric-vehicle slabs */
+--gradient-aurora: linear-gradient(120deg, #efdf00 0%, #ff6b9d 45%, #1885d1 100%)
+--gradient-soft:   linear-gradient(180deg, rgba(232, 22, 48, 0.08) 0%, transparent 100%)
+--border:          #d9d9d6
+--rule:            #000000
+```
+
+Rule: the aurora gradient is the identity moment — used on hero backdrop and one large text fill per page. Buttons stay flat yellow or flat red, never gradient.
+
+## 3. Typography Rules
+
+- **Display + headings:** `NouvelR`, fallback `sans-serif`. Weight 700 for hero, weight 500 for editorial heads. Tracked −1% above 40px.
+- **Body + UI:** NouvelR regular, 16–18px body, 1.55 line-height.
+- **Labels + spec rows:** uppercase, tracked 8%, 12px, ink-muted.
+- **Numerals (range, kWh, 0-100):** tabular, weight 700, paired with small unit labels.
+
+Scale: 12 / 14 / 16 / 20 / 28 / 40 / 56 / 80 / 120.
+
+Single typeface for the whole site. NouvelR carries the brand alone — never pair with a serif or grotesque sibling.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: `--accent-yellow` fill, ink text, radius 4px, padding 12/24, weight 700.
+- Secondary: `--accent-red` fill, white text, radius 4px.
+- Ghost: transparent, 1px ink border, ink text, radius 4px.
+- Hover: 8% darken on yellow, `--accent-red-hover` on red. No scale, no glow.
+
+**Cards / model tiles**
+- White surface, 1px `--border`, radius 4px. Photo top, model name in NouvelR 28px, range/price strip below.
+- Hover: border shifts to `--accent-red`. No shadow lift.
+
+**Inputs**
+- White fill, 1px `--border`, radius 4px, 10/14 padding. Focus: 2px `--accent-blue` ring, no offset.
+
+**Nav**
+- Fixed top, white fill, 1px bottom border. Diamond logomark left, model groups center, account/build right. Active link gets a 2px `--accent-yellow` underline.
+
+**Hero gradient panel**
+- Full-bleed `--gradient-aurora` slab, 60–80vh tall.
+- Headline overlaid in white at 80–120px, weight 700, tight tracking.
+- Yellow primary CTA bottom-left, ink text on the gradient.
+
+**Diamond motif**
+- Used as section anchor: a single outline diamond, 24–48px, ink-stroke 2px, sitting at the start of editorial sections. Never as repeating pattern.
+
+## 5. Layout Principles
+
+- 1320px max, 24px gutter, 12 column.
+- 4px base. 4 / 8 / 16 / 24 / 32 / 48 / 80 / 120.
+- Alternate paper-white slab → full-bleed aurora hero → spec slab → blue EV slab.
+- Section breaks at 96–120px on desktop.
+- Asymmetric column splits (60/40 photo + spec) over symmetric grids.
+
+## 6. Depth & Elevation
+
+Atmospheric, soft. Depth from gradient saturation and tonal step between white and `--bg-alt`. Allowed: 1px borders, 2px keyline rules, soft `--gradient-soft` wash behind featured cards. Forbidden: drop shadows on cards, glow effects, backdrop blur on nav.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Deploy the aurora gradient on hero backdrop once per page, plus one large text fill maximum.
+- Keep buttons flat: yellow primary, red secondary, ghost tertiary. Never gradient buttons.
+- Use the diamond motif as a single section anchor, not a repeating wallpaper.
+- Hold to 4px radius across the system — softer than Ferrari, sharper than Cal.com.
+
+**Don't**
+- Apply the aurora gradient to buttons, links, or body type.
+- Pair yellow and red in the same component — alternate by section.
+- Add drop shadows, glows, or backdrop-blur nav.
+- Mix in a serif or condensed grotesque — NouvelR carries the page.
+- Use the diamond as a repeating tile background.
+
+## 8. Responsive Behavior
+
+- Hero headline scales 120 → 40 on mobile, retains weight 700.
+- Aurora gradient backdrop retains full bleed; CTA stacks below headline.
+- Nav collapses to ink hamburger on white below 1024px; diamond logomark stays.
+- 12-column grid reflows to single column below 768px; 64px section rhythm.
+
+## 9. Agent Prompt Guide
+
+Bias: paper-white canvas, full-bleed aurora gradient (yellow → magenta → cyan) on hero, single NouvelR typeface, flat yellow primary + flat red secondary CTAs, 4px radii, diamond motif as section anchor, alternating white / aurora / blue-EV slabs, sun-lit color-rich vehicle photography.
+
+Reject: dark-mode default, gradient-filled buttons or text links, multi-typeface mixing, repeating diamond wallpaper, drop shadows on cards, backdrop-blur nav, moody automotive lighting, pill buttons, glassmorphism, replacing NouvelR with Inter or a serif.


### PR DESCRIPTION
Wave 3 of cinematic-family DESIGN.md depth. Four auto/luxury brand entries under `design-md/cinematic/`. Tokens researched from live brand sites (firecrawl branding extraction on bmw.com, ferrari.com, lamborghini.com, renault.fr).

## Per-brand

**`design-md/cinematic/bmw.md` — Editorial Performance Blue**
Paper-white canvas with full-bleed automotive photography. Single corporate blue `#1c69d4` on CTAs, deeper marine `#0653b6` on hover. M-gradient (`#2e9bd6 → #1c69d4 → #0653b6`) reserved for one performance moment per page — never on body or buttons. BMW Type Next Web headlines, Helvetica Neue body. Sharp 3px radii. Tracked uppercase spec labels. Restraint over chrome.

**`design-md/cinematic/ferrari.md` — Chiaroscuro Rosso Corsa**
Alternating full-bleed black `#000` and paper-white `#fff` slabs. FerrariSans is the single typeface — weight 700 nameplates, oversized 88–140px lap-time numerals. Rosso Corsa `#eb2323` appears once per visual frame as CTA, rule, or numeral fill. Modena yellow `#f6e500` reserved for racing-content slabs only — never paired with red in the same hero. 0px radii everywhere.

**`design-md/cinematic/lamborghini.md` — Black Cathedral Gold**
True `#000000` canvas (not charcoal — true black is the differentiator). LamboType nameplates pushed to 120–168px. Single warm-gold accent `#ffc000` on primary CTAs, `#917300` engraved-gold for active state. Three-tone black depth (`#000` / `#0a0a0a` / `#141414`). Hex motif used as 1px section seam, never repeating wallpaper. Sharp 0px radii. Vehicle photographed as plinth-lit sculpture.

**`design-md/cinematic/renault.md` — Aurora Pop Geometric**
Paper-white canvas with full-bleed aurora gradient (`#efdf00 → #ff6b9d → #1885d1`) on hero. NouvelR carries the entire page — no secondary typeface. Flat yellow primary `#efdf00` and flat red secondary `#e91630` CTAs (never gradient buttons). Tertiary blue `#1885d1` on EV slabs. 4px radii — softer than Ferrari, sharper than Cal.com. Diamond logomark as section anchor, never as repeating tile.

## README updates

- `**Shipped samples in this repo:**` line gains 4 entries.
- Cinematic Dark family table gains 4 rows (BMW, Ferrari, Lamborghini, Renault) with swatch + type + external reference.

## Method

- Firecrawl `branding` format on each brand's live site for measured tokens (color hex, font families, button radii, base unit).
- All 9 canonical sections per AGENTS.md, ≤150 words per section, hex with role names, no marketing filler, no emojis.
- Section 9 ends with explicit Bias / Reject clauses for agent prompting.

## Untouched

Banner, hero, gallery, anti-slop, recipes, comparisons, community takes, FAQ. Open only — do not merge.