### PR TITLE
add: 5 DESIGN.md (MongoDB, NVIDIA, MiniMax, Toss, OpenCode AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Submit more: handle, verbatim quote ≤280 chars, tweet URL, engagement numbers.
 
 Not sorted by industry. Sorted by **visual character** — because that's how designers actually pick. Each family links to (1) a working `DESIGN.md` in `/design-md/<family>/`, (2) canonical external references, (3) a one-line swatch + type spec so you can eyeball fit before cloning.
 
-**Shipped samples in this repo:** [warm/claude.md](design-md/warm/claude.md) · [warm/mercury.md](design-md/warm/mercury.md) · [terminal/ollama.md](design-md/terminal/ollama.md) · [terminal/warp.md](design-md/terminal/warp.md) · [editorial/linear.md](design-md/editorial/linear.md) · [editorial/vercel.md](design-md/editorial/vercel.md) · [data-dense/clickhouse.md](design-md/data-dense/clickhouse.md) · [data-dense/posthog.md](design-md/data-dense/posthog.md) · [data-dense/datadog.md](design-md/data-dense/datadog.md) · [cinematic/runway.md](design-md/cinematic/runway.md) · [cinematic/tavus.md](design-md/cinematic/tavus.md) · [cinematic/cohere.md](design-md/cinematic/cohere.md) · [playful/figma.md](design-md/playful/figma.md) · [playful/canva.md](design-md/playful/canva.md) · [glass/arc.md](design-md/glass/arc.md) · [glass/apple.md](design-md/glass/apple.md) · [brutalist/the-verge.md](design-md/brutalist/the-verge.md) · [indie/granola.md](design-md/indie/granola.md) · [remix/linear-x-claude.md](design-md/remix/linear-x-claude.md) · [remix/warp-x-sentry.md](design-md/remix/warp-x-sentry.md) · [remix/stripe-x-a24.md](design-md/remix/stripe-x-a24.md)
+**Shipped samples in this repo:** [warm/claude.md](design-md/warm/claude.md) · [warm/mercury.md](design-md/warm/mercury.md) · [terminal/ollama.md](design-md/terminal/ollama.md) · [terminal/warp.md](design-md/terminal/warp.md) · [terminal/opencode.md](design-md/terminal/opencode.md) · [editorial/linear.md](design-md/editorial/linear.md) · [editorial/vercel.md](design-md/editorial/vercel.md) · [data-dense/clickhouse.md](design-md/data-dense/clickhouse.md) · [data-dense/posthog.md](design-md/data-dense/posthog.md) · [data-dense/datadog.md](design-md/data-dense/datadog.md) · [data-dense/mongodb.md](design-md/data-dense/mongodb.md) · [cinematic/runway.md](design-md/cinematic/runway.md) · [cinematic/tavus.md](design-md/cinematic/tavus.md) · [cinematic/cohere.md](design-md/cinematic/cohere.md) · [cinematic/nvidia.md](design-md/cinematic/nvidia.md) · [cinematic/minimax.md](design-md/cinematic/minimax.md) · [playful/figma.md](design-md/playful/figma.md) · [playful/canva.md](design-md/playful/canva.md) · [playful/toss.md](design-md/playful/toss.md) · [glass/arc.md](design-md/glass/arc.md) · [glass/apple.md](design-md/glass/apple.md) · [brutalist/the-verge.md](design-md/brutalist/the-verge.md) · [indie/granola.md](design-md/indie/granola.md) · [remix/linear-x-claude.md](design-md/remix/linear-x-claude.md) · [remix/warp-x-sentry.md](design-md/remix/warp-x-sentry.md) · [remix/stripe-x-a24.md](design-md/remix/stripe-x-a24.md)
 
 ### 1. Editorial Minimalism
 
@@ -404,6 +404,7 @@ Charts are the hero. Tight spacing, saturated categorical palette, fixed-width n
 | Grafana | `#111217 / #f47c1b / multi-series` | Inter | [grafana.com](https://grafana.com) |
 | Sentry | `#362d59 / #f6827d / #584774` | Rubik | [sentry.io](https://sentry.io) |
 | Supabase | `#171717 / #3ecf8e` | Custom + mono | [supabase.com](https://supabase.com) |
+| MongoDB | `#001e2b / #00ed64 / #00684a` | Euclid Circular A + Source Code Pro | [mongodb.com](https://mongodb.com) |
 
 ### 5. Cinematic Dark
 
@@ -415,6 +416,7 @@ Film-grade gradients, oversized type, motion-forward, media-heavy hero. Built fo
 | ElevenLabs | `#0a0a0a / electric blue / wave motifs` | Inter | [elevenlabs.io](https://elevenlabs.io) |
 | Minimax | `#000 / neon lime on charcoal` | Custom + mono | [minimax.ai](https://minimax.ai) |
 | Midjourney | `#000 / earth tones + lilac` | Editorial serif | [midjourney.com](https://midjourney.com) |
+| NVIDIA | `#000 / #76b900 signature green / #ffffff` | NVIDIA Sans / Helvetica Neue | [nvidia.com](https://nvidia.com) |
 
 ### 6. Playful Color
 
@@ -427,6 +429,7 @@ High-saturation, illustrated accents, rounded corners, decorative shapes. Consum
 | Duolingo | `#58cc02 / #fff / #ff4b4b` | DIN Rounded | [duolingo.com](https://duolingo.com) |
 | Mailchimp | `#ffe01b / #000` | Cooper Hewitt + GT America | [mailchimp.com](https://mailchimp.com) |
 | Cal.com | `#292929 / #fff / single accent` | Inter | [cal.com](https://cal.com) |
+| Toss | `#fff / #3182f6 Toss Blue / #191f28` | Toss Product Sans + Noto Sans KR | [toss.im](https://toss.im) |
 
 ### 7. Glass / Soft-Futurism
 

--- a/design-md/cinematic/minimax.md
+++ b/design-md/cinematic/minimax.md
@@ -1,0 +1,120 @@
+# MiniMax — Cinematic Lab
+
+Reference DESIGN.md for AI-lab cinematic: pure black canvas, neon-lime accent on charcoal chrome, geometric DM Sans / Outfit type, pill-shaped CTAs.
+
+## 1. Visual Theme & Atmosphere
+
+Cinematic lab. The page reads like a research-trailer reel — black canvas, oversized geometric type, demos that loop without a play button, and one neon-lime moment per screen that signals "this is the action." Chrome shrinks; the model demos are the subject. Marketing surfaces stay dark by default; the rare light section is a deliberate inversion that frames a paper or product spec.
+
+Mood: laboratory-grade, kinetic, deliberately understated until the lime CTA fires.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #000000   /* canvas */
+--bg-alt:          #0a0a0a
+--surface:         #181e25   /* charcoal — observed brand chrome */
+--surface-2:       #232a33
+--text:            #ffffff
+--text-muted:      #c5c9cf
+--text-dim:        #7a808a
+--border:          #2a3038
+--border-strong:   #3a4049
+
+--accent:          #c8ff00   /* neon lime — primary action + brand */
+--accent-hover:    #d8ff3a
+--accent-deep:     #9bcc00   /* hover-pressed, ink-on-light variant */
+--accent-soft:     #e9ff86   /* tinted callouts */
+
+/* inverse — used for spec / paper sections only */
+--bg-inverse:      #ffffff
+--text-inverse:    #181e25
+--border-inverse:  #e1e3e6
+
+--success:         #6ee7b7
+--warning:         #ffd166
+--danger:          #ff5d5d
+```
+
+Rule: lime `--accent` carries one moment per viewport and never tints body text. Charcoal `--surface` is the resting chrome state; pure black is for full-bleed media. Inverse light sections are the exception, not the rhythm.
+
+## 3. Typography Rules
+
+- **Display + headlines:** `Outfit`, fallback `Helvetica Neue`, `Helvetica`, `Arial`, system. Weight 500–700, tight tracking (−1% at large sizes). Outfit's geometric construction reads as "model architecture diagram."
+- **Body + UI:** `DM Sans`, fallback `Helvetica Neue`, `Helvetica`, `Arial`, system. Weight 400/500. Line-height 1.5–1.6.
+- **UI labels:** DM Sans weight 500, 13–14px, uppercase only for category eyebrows (tracked +4%).
+- **Numerals:** tabular figures on benchmark tables, parameter counts, latency stats.
+- **Mono:** `JetBrains Mono`, fallback `SF Mono`. Used for code samples, API snippets, citation hashes.
+
+Scale: 12 / 14 / 16 / 20 / 28 / 40 / 56 / 80 / 112.
+
+Headlines balance (`text-wrap: balance`); body reflows (`text-wrap: pretty`). Display goes to 80–112px on launches.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: lime fill `--accent`, charcoal text `--surface`, radius 60px (pill), padding 12/24, weight 500. Hover: `--accent-hover`. No lift, no scale.
+- Secondary: white fill, charcoal text, radius 12px, weight 500. Used inside dark sections to invert hierarchy.
+- Tertiary / link: white text, lime underline on hover.
+- Destructive: `--danger` fill, white text, only on confirm modals.
+
+**Cards / model tiles**
+- `--surface` fill, 1px `--border`, radius 12px. Padding 24.
+- Hero model cards run looping demo videos with text overlay; bottom gradient scrim for legibility.
+- Hover: 1px `--accent` border, 200ms ease. No scale.
+
+**Inputs**
+- `--bg-alt` fill, 1px `--border-strong`, radius 12px, padding 12/14. Focus: 2px `--accent` ring with 1px offset.
+
+**Nav**
+- Fixed top, `--bg` fill with 80% opacity and 12px backdrop blur. White links, lime underline on active.
+
+**Demo player**
+- Autoplay muted, looped, 16:9 minimum. No controls visible until hover. Reduced-motion users get a static still frame and a play affordance.
+
+## 5. Layout Principles
+
+- Full-bleed hero (100vw, 80–100vh) anchored on a model demo loop.
+- 1280px max for content sections, 32px gutter, 12-column.
+- 8px base. 8 / 16 / 24 / 32 / 48 / 64 / 96 / 128.
+- Generous vertical whitespace between sections (96–128px).
+- Spec / benchmark tables break the editorial rhythm and run dense.
+
+## 6. Depth & Elevation
+
+Flat surfaces with hard borders. Depth comes from:
+- Surface tonal shift (`--bg → --surface → --surface-2`)
+- 1px `--border` and `--border-strong`
+- Demo media hierarchy
+
+Modals get `0 24px 64px rgba(0, 0, 0, 0.72)` over a 70% black scrim. No drop shadows on cards or buttons. Reserve subtle glow effects for hovered demo tiles only.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Open with a full-bleed model demo loop. No stock photography.
+- Reserve lime for the single CTA moment per viewport.
+- Oversize the launch headline. 80–112px on hero.
+- Use tabular numerals for benchmark deltas (1.7×, 2.5×, +43%).
+- Pair pill primary CTAs with rectangular `12px` secondary buttons — the geometric collision is the brand.
+
+**Don't**
+- Use lime inside body text or as a paragraph tint.
+- Use multiple accents per viewport.
+- Soften corners past 16px on cards.
+- Switch to a light theme as the marketing default.
+- Add purple-to-pink gradients, glassmorphism, or rainbow accents.
+
+## 8. Responsive Behavior
+
+- Hero demo remains full-bleed; headline scales 112 → 36 on mobile.
+- Nav collapses to drawer at 1024px, full-screen overlay below 768px.
+- Spec tables become horizontally scrollable below 640px (preserve density, no stacking).
+- Autoplay disabled on mobile per bandwidth respect; static poster substitutes.
+- Body type holds 16px on mobile.
+
+## 9. Agent Prompt Guide
+
+Bias: pure black `#000000` canvas with charcoal `#181e25` chrome, single neon-lime `#c8ff00` moment per viewport reserved for primary CTA, Outfit display headlines paired with DM Sans body, oversized launch type (80–112px), pill primary CTAs at 60px radius alongside 12px-radius secondaries, looping demo media as the hero artifact, tabular numerals on benchmark tables.
+
+Reject: light-mode marketing pages, multi-color palettes, soft pastel gradients, glassmorphism, scale-on-hover lifts, hero stock photography in place of demo loops, decorative illustration in chrome, lime tints on body type.

--- a/design-md/cinematic/nvidia.md
+++ b/design-md/cinematic/nvidia.md
@@ -1,0 +1,116 @@
+# NVIDIA — Cinematic Compute
+
+Reference DESIGN.md for GPU-vendor cinematic: chrome-black canvas, signature green action, video-led hero, hard-edged grotesque headlines.
+
+## 1. Visual Theme & Atmosphere
+
+Cinematic compute. The page reads like a hardware launch reel — black canvas, full-bleed video of die shots and rendered scenes, green CTA punching through. Type stays sharp, narrow, almost industrial. There is exactly one accent and it is the green; everything else is grayscale.
+
+Mood: high-energy, precision-engineered, motion-forward.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #000000   /* canvas */
+--bg-alt:          #0d0d0d
+--surface:         #1a1a1a
+--surface-2:       #2a2a2a
+--text:            #ffffff
+--text-muted:      #b8b8b8
+--text-dim:        #767676
+--border:          #333333
+--border-strong:   #4d4d4d
+
+--accent:          #76b900   /* signature green — primary CTA + brand */
+--accent-hover:    #8fd400
+--accent-deep:     #5a8d00   /* hover-pressed, dark variants */
+--accent-soft:     #c9e892   /* tinted callouts only */
+
+--secondary:       #10b1fb   /* developer / data accent, sparingly */
+--success:         #76b900
+--warning:         #ffb800
+--danger:          #d13438
+```
+
+Rule: green and only green for primary action and brand mark. Cyan `--secondary` is reserved for developer surfaces (CUDA, RAPIDS, NeMo). Never gradient between the two; they are not partners.
+
+## 3. Typography Rules
+
+- **Display + headlines:** `NVIDIA Sans` (NALA), fallback `Helvetica Neue`, `Arial`, system. Weight 500–700, tight tracking (−1% at large sizes).
+- **Body:** NVIDIA Sans regular, weight 400, 16–18px, line-height 1.5.
+- **UI labels:** NVIDIA Sans weight 500, 12–14px, uppercase only for category eyebrows (tracked +6%).
+- **Numerals:** tabular figures on spec tables, benchmark charts, pricing.
+- **Mono:** `JetBrains Mono`, fallback `SF Mono`. Used for code samples, command snippets, telemetry.
+
+Scale: 12 / 14 / 16 / 18 / 24 / 32 / 48 / 72 / 96 / 128.
+
+Display headlines go big. 96px and up for product launches.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: `--accent` fill, black text, radius 4px, padding 12/24, weight 600. Hover: `--accent-hover`. No lift, no scale.
+- Secondary: transparent fill, 1px white border, white text. Hover: 1px `--accent` border.
+- Tertiary / link: white text, green underline on hover.
+- Destructive: `--danger` fill, white text, only on confirm modals.
+
+**Cards / product tiles**
+- `--surface` fill, 1px `--border`, radius 4px. Padding 24.
+- Hero product cards run full-bleed images with text overlay; gradient scrim `linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.8) 100%)` for legibility.
+- Hover: 1px `--accent` border, 200ms ease. No scale, no glow.
+
+**Inputs**
+- `--bg-alt` fill, 1px `--border-strong`, radius 4px, padding 10/14. Focus: 2px `--accent` ring with 1px offset.
+
+**Nav**
+- Fixed top, `--bg` fill with 90% opacity and 8px backdrop blur. White links, green underline on active. Mega-menu opens flush, full-width, dark.
+
+**Video hero**
+- Autoplay muted, 100vw × 80vh minimum. Loop. Subtle bottom scrim for headline legibility. Reduced-motion users get a static still frame.
+
+## 5. Layout Principles
+
+- Full-bleed hero (100vw, 80–100vh).
+- 1440px max for content sections, 32px gutter, 12-column.
+- 8px base. 8 / 16 / 24 / 32 / 48 / 64 / 96 / 128.
+- Generous vertical whitespace between sections (96–128px).
+- Spec tables break grid and run dense.
+
+## 6. Depth & Elevation
+
+Flat surfaces with hard borders. Depth comes from:
+- Surface tonal shift (`--bg → --surface → --surface-2`)
+- 1px `--border` and `--border-strong`
+- Video and image hierarchy
+
+Modals get `0 24px 64px rgba(0, 0, 0, 0.72)` over a 70% black scrim. No soft glows on cards. Reserve glow effects for chart highlights only.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Open with full-bleed video. Die shots, rendered scenes, lab footage, robotaxi POV.
+- Oversize the launch headline. 96px+.
+- Lock the green to action and brand; let chrome stay grayscale.
+- Use tabular numerals for benchmark deltas (1.7×, 2.5×, +43%).
+- Keep corners at 4px. Hard edges read as engineered.
+
+**Don't**
+- Mix green and cyan in the same component.
+- Use light backgrounds. NVIDIA marketing is dark by default.
+- Soften corners past 8px.
+- Add purple gradients, glassmorphism, or pastel accents.
+- Replace video hero with stock photography.
+
+## 8. Responsive Behavior
+
+- Hero video remains full-bleed; headline scales 128 → 40 on mobile.
+- Mega-menu collapses to drawer at 1024px, full-screen overlay below 768px.
+- Spec tables become horizontally scrollable below 640px (preserve density, no stacking).
+- Autoplay disabled on mobile per bandwidth respect; static poster frame substitutes.
+- Body type holds 16px on mobile.
+
+## 9. Agent Prompt Guide
+
+Bias: black `#000000` canvas, signature green `#76b900` reserved for primary action and brand mark only, NVIDIA Sans / Helvetica Neue tight grotesque, oversized display headlines (96px+), full-bleed video hero, 4px radii, tabular numerals on benchmark tables, mega-menu nav with backdrop blur.
+
+Reject: light-mode marketing pages, multi-accent palettes, soft pastel gradients, glassmorphism, rounded-pill buttons, hero stock photography in place of video, scaled hover lifts, decorative illustration in chrome.

--- a/design-md/data-dense/mongodb.md
+++ b/design-md/data-dense/mongodb.md
@@ -1,0 +1,130 @@
+# MongoDB — Data-Dense Atlas
+
+Reference DESIGN.md for developer database UIs: forest-green leaf brand, deep slate chrome, dashboard-first density with marketing surfaces in light editorial.
+
+## 1. Visual Theme & Atmosphere
+
+The cluster is the page. Marketing reads like a developer brochure — light backgrounds, generous whitespace, code panels framed as the hero. The Atlas console flips to deep slate so collection counts, IOPS sparklines, and shard maps stay legible across long on-call windows. One forest-green leaf earns the brand moment; everything else is slate, ink, or a measured chart hue.
+
+Mood: technical, enterprise-trustworthy, never decorative.
+
+## 2. Color Palette & Roles
+
+```
+/* marketing surface — light */
+--bg:              #ffffff
+--bg-alt:          #f9fafb
+--surface:         #f3f5f4   /* tinted leaf wash */
+--text:            #001e2b   /* slate ink */
+--text-muted:      #5d6c74
+--border:          #e1e7e4
+
+/* in-app shell — slate */
+--bg-app:          #001e2b   /* MongoDB slate */
+--bg-app-alt:      #023430
+--surface-app:     #0a3a3f
+--surface-app-2:   #112c33
+--text-app:        #ffffff
+--text-app-muted:  #c1c7c6
+--border-app:      #1c4a4f
+
+/* brand */
+--accent:          #00ed64   /* leaf green, primary CTA + brand */
+--accent-hover:    #00c757
+--accent-deep:     #00684a   /* forest, ink-on-light variant */
+--accent-soft:     #c0fae6   /* tinted callouts */
+
+/* status */
+--status-ok:       #00684a
+--status-warn:     #b45309
+--status-error:    #db3030
+--status-info:     #016bf8
+
+/* categorical chart palette — preserve order */
+--chart-1: #00684a   /* forest */
+--chart-2: #016bf8   /* electric blue */
+--chart-3: #b45309   /* amber */
+--chart-4: #889397   /* slate gray */
+--chart-5: #00d2ff   /* cyan */
+--chart-6: #db3030   /* error red */
+--chart-7: #5d4caf   /* indigo */
+--chart-8: #00ed64   /* leaf — reserve for highlight */
+```
+
+Rule: leaf green is reserved for primary action and the brand mark. On dashboards, the deep `--accent-deep` carries text that needs to read as "MongoDB-flavored" without screaming. Status hues are reserved for state; never reuse for arbitrary series.
+
+## 3. Typography Rules
+
+- **UI + body:** `Euclid Circular A`, fallback `Inter`, fallback system. Weight 400/500/700.
+- **Headlines:** Euclid weight 500–700. Marketing display tops out near 64px.
+- **Numerals:** tabular figures globally on metric tiles, query rows, alert tables.
+- **Code + query language:** `Source Code Pro`, fallback `JetBrains Mono`, `SF Mono`. Used for query syntax, log lines, document JSON, shell prompts.
+
+Scale: 11 / 12 / 14 / 16 / 18 / 22 / 28 / 36 / 48 / 64.
+
+Body lines hold a measure of 65–72 characters on marketing pages; in-app rows ignore measure and let tables breathe to viewport.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: leaf fill `--accent`, slate text, radius 6px, padding 10/18, weight 500.
+- Secondary on light: white fill, 1px `--border`, slate text. Hover: `--surface`.
+- Secondary on dark shell: transparent fill, 1px `--text-app-muted`, white text.
+- Destructive: `--status-error` fill, white text, only on confirm modals.
+
+**Cards / dashboard tiles**
+- Marketing: white fill, 1px `--border`, radius 8px, 24px padding.
+- App: `--surface-app` fill, 1px `--border-app`, radius 6px, 16px padding. Eyebrow in 11px uppercase tracked +4%.
+- Hover: 1px `--accent` border on app tiles. No shadow, no lift.
+
+**Inputs**
+- 1px border, radius 6px, padding 10/12. Focus: 2px `--accent` ring with 1px offset.
+- Code inputs (Compass shell, Atlas query bar) use `--bg-app-alt` fill on light surfaces — terminal-in-page treatment.
+
+**Tables**
+- 32px row height. Hairline border separators. Sticky header in 12px uppercase mono. Tabular numerals throughout. Right-align numerics, left-align strings, center status pills.
+
+**Charts**
+- 1px tick marks, axis labels in `--text-app-muted` 11px. Gridlines `--border-app` at 30% opacity.
+- Series rendered in `--chart-1..8` declared order. Legend chips top-right with 8px swatch.
+- Tooltips: `--bg-app` fill, white text, 1px `--accent-deep` border, radius 4px.
+
+## 5. Layout Principles
+
+- App shell uses 100% viewport. Left nav 240px, content fills.
+- Marketing 1200px max, 24px gutter, 12-column.
+- 4px base. 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64.
+- Dashboards default to 12-column draggable grid; tiles snap to 6/4/3/2 widths.
+
+## 6. Depth & Elevation
+
+Flat. Border + tonal shift only. Modals get `0 16px 48px rgba(0, 30, 43, 0.32)` over a 60% slate scrim. Tooltips lift via 1px accent border, not shadow. Marketing cards get a single `0 1px 2px rgba(0, 30, 43, 0.04)` for soft definition only.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Render every metric in tabular Euclid numerals.
+- Lock chart series to the declared categorical palette order across all dashboards — colors carry meaning.
+- Keep the in-app shell on slate `#001e2b`. Light marketing only.
+- Use code panels in the hero — show a `db.collection.aggregate(...)` block, not stock photography.
+
+**Don't**
+- Use leaf green for body text or as a tint behind paragraphs.
+- Soften corners past 8px on marketing, 6px in-app.
+- Replace tabular figures with proportional figures inside metric tiles.
+- Add gradient fills under area charts. Solid fills with 30% opacity only.
+- Introduce a second brand color "for variety". Leaf is the only branded hue.
+
+## 8. Responsive Behavior
+
+- Left nav collapses to 56px icon rail at 1280px, hidden behind hamburger below 768px.
+- Dashboard tiles reflow 12 → 6 → 3 → 1 column at 1440 / 1024 / 768.
+- Tables become stacked KV cards below 640px, numbers retained in tabular.
+- Code panels in marketing become horizontally scrollable (no soft-wrap of JSON).
+- Hero headline scales 64 → 32 on mobile.
+
+## 9. Agent Prompt Guide
+
+Bias: deep slate `#001e2b` app shell paired with light marketing, leaf green `#00ed64` primary action, Euclid Circular A with tabular numerals, 6–8px radii, eight-color categorical chart palette in declared order, dense 32px table rows, persistent left nav, hairline-only borders, code panels as the hero artifact.
+
+Reject: light-mode dashboards, multi-color brand palettes, gradient chart fills, rounded "bubble" tiles, proportional numerals on metrics, hero illustrations in place of code, decorative emoji in chrome, "growth-marketing" pastel washes.

--- a/design-md/playful/toss.md
+++ b/design-md/playful/toss.md
@@ -1,0 +1,115 @@
+# Toss — Playful Fintech
+
+Reference DESIGN.md for Korean-fintech playful: Toss Blue against bright white, Toss Product Sans paired with Noto Sans KR, generous radii, friendly mood, mobile-first density.
+
+## 1. Visual Theme & Atmosphere
+
+Playful fintech. The page reads like a friend explaining money — bright white surfaces, one confident blue, generous radii, illustrations of cards and coins rendered in flat vector. The brand is warm without being childish; type stays geometric, copy stays plainspoken, and every CTA invites a tap. Korean-first, but the system holds in Latin script.
+
+Mood: friendly, approachable, confident, never sterile.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #ffffff   /* canvas */
+--bg-alt:          #f9fafb
+--surface:         #f2f4f6   /* cool gray surface lift */
+--surface-2:       #e8f3ff   /* tinted blue wash for callouts */
+--text:            #191f28   /* near-ink */
+--text-secondary:  #333d4b   /* body copy */
+--text-muted:      #6b7684
+--text-dim:        #8b95a1
+--border:          #e5e8eb
+--border-strong:   #d1d6db
+
+--accent:          #3182f6   /* Toss Blue — primary action + brand */
+--accent-hover:    #1b64da
+--accent-deep:     #1e40af   /* pressed / dark variant */
+--accent-soft:     #e8f3ff   /* tinted callouts, secondary button bg */
+
+--success:         #00c896   /* mint, positive balance */
+--warning:         #ff9500   /* amber, attention */
+--danger:          #f04452   /* coral red, decline / loss */
+--info:            #3182f6
+```
+
+Rule: Toss Blue is the only branded hue. Status colors are reserved for state (positive balance, attention, decline). Never reuse status hues for decoration. The tinted blue wash `--surface-2` carries callouts and secondary buttons — it is the brand's softening move.
+
+## 3. Typography Rules
+
+- **Headlines + display:** `Toss Product Sans`, fallback `Pretendard`, `-apple-system`, `BlinkMacSystemFont`, `Apple SD Gothic Neo`, `Noto Sans KR`, system. Weight 600–700, tight tracking (−1% at large sizes).
+- **Body + UI:** `Toss Product Sans`, fallback as above. Weight 400/500. Line-height 1.5–1.6. Korean glyphs rendered via `Noto Sans KR` and `Apple SD Gothic Neo` fallbacks.
+- **UI labels:** Toss Product Sans weight 500, 13–15px.
+- **Numerals:** tabular figures globally on balances, transaction lists, charts.
+- **Mono:** `JetBrains Mono`, fallback `SF Mono`. Used for transaction IDs, code samples, OTPs.
+
+Scale: 12 / 14 / 15 / 17 / 20 / 24 / 32 / 40 / 50 / 66.
+
+Hero headlines run 50–66px on desktop. Korean and Latin glyphs share metrics within Toss Product Sans.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: Toss Blue fill `--accent`, white text `#f9fafb`, radius 7px, padding 14/20, weight 500. Hover: `--accent-hover`. Pressed: `--accent-deep`. No lift, no scale.
+- Secondary: tinted blue fill `--surface-2`, deep blue text `--accent-hover`, radius 7px. The two-step blue is Toss's signature hierarchy.
+- Tertiary / link: `--text-secondary`, blue underline on hover.
+- Destructive: `--danger` fill, white text, only on confirm modals.
+
+**Cards / list items**
+- White fill, 1px `--border`, radius 12px, padding 20. Soft shadow `0 1px 3px rgba(25, 31, 40, 0.04)` only.
+- Transaction rows: 1px hairline divider, no card chrome, 64px row height for tap targets.
+- Hover: 1px `--border-strong`. No lift.
+
+**Inputs**
+- `--surface` fill, no border at rest, radius 12px, padding 16/20 (large tap targets).
+- Focus: 2px `--accent` ring, no offset. Label floats above on focus.
+- Currency inputs use right-aligned tabular numerals.
+
+**Nav**
+- Mobile bottom-tab nav primary, 56px tall, 5 icons max, blue active state.
+- Web top nav: white fill, 1px bottom `--border`, blue underline on active.
+
+**Illustrations**
+- Flat vector. Cards, coins, characters. 2–3 hues per illustration drawn from blue + soft neutrals.
+- Avoid photorealism, avoid drop shadows on illustration art.
+
+## 5. Layout Principles
+
+- Mobile-first. 360–430px primary canvas. Web mirrors mobile column at 480px max content width inside a 1200px shell.
+- 4px base. 4 / 8 / 12 / 16 / 20 / 24 / 32 / 48.
+- Generous vertical rhythm between content blocks (32–48px).
+- Dense list views at 64px row height for tap-target compliance.
+
+## 6. Depth & Elevation
+
+Soft shadows allowed sparingly — single `0 1px 3px rgba(25, 31, 40, 0.04)` on cards, `0 8px 24px rgba(25, 31, 40, 0.08)` on modals and bottom sheets. No neumorphism. No stacked shadows. Tap targets get a brief scale(0.98) press feedback (96ms ease-out).
+
+## 7. Do's and Don'ts
+
+**Do**
+- Use Toss Blue as the single confident accent.
+- Pair primary blue with the tinted blue secondary — the two-step is the signature.
+- Ship bottom-sheet modals on mobile, not page-pushed dialogs.
+- Render every monetary value in tabular numerals.
+- Write copy in plainspoken Korean / English — short sentences, friendly verbs.
+
+**Don't**
+- Introduce a second saturated brand hue.
+- Soften corners past 16px (Toss tops out at 12–16px on cards, 7px on buttons).
+- Use dark mode as the default canvas.
+- Fill backgrounds with gradients (flat fills only).
+- Mix more than two type weights per screen.
+
+## 8. Responsive Behavior
+
+- Mobile is canonical. Desktop mirrors the mobile column inside a centered 480px content lane.
+- Headlines scale 66 → 28 on mobile.
+- Bottom-tab nav on mobile becomes top nav with same 5 destinations on web.
+- Modals become full-screen sheets below 640px.
+- Lists become full-bleed at 360px viewport.
+
+## 9. Agent Prompt Guide
+
+Bias: bright white `#ffffff` canvas, single Toss Blue `#3182f6` accent paired with a tinted blue `#e8f3ff` secondary, Toss Product Sans with Noto Sans KR fallback, 7px radii on buttons and 12px on cards, mobile-first 480px content lane, 64px tap-target row heights, tabular numerals on every monetary value, flat-vector illustrations of cards / coins, bottom-sheet modals on mobile.
+
+Reject: dark-mode marketing as default, multi-accent palettes, gradient fills, drop-shadow heavy cards, photorealistic imagery, soft-pill buttons over 16px radius, dense desktop-first dashboards, decorative emoji in chrome.

--- a/design-md/terminal/opencode.md
+++ b/design-md/terminal/opencode.md
@@ -1,0 +1,117 @@
+# OpenCode AI — Terminal Native
+
+Reference DESIGN.md for OSS terminal coding agent: near-black canvas, off-white text, phosphor-green action, IBM Plex Mono everywhere, hard edges.
+
+## 1. Visual Theme & Atmosphere
+
+Terminal native. The page reads like the product — a TUI rendered in HTML. Near-black canvas, off-white text, monospace from chrome to body. The only color belongs to the prompt cursor, the active line, and the accept-action: a single phosphor green. Nothing scales on hover, nothing softens past 4px, nothing exists that wouldn't render in 256-color terminal mode.
+
+Mood: ascetic, kinetic, opinionated, OSS-honest.
+
+## 2. Color Palette & Roles
+
+```
+--bg:              #080808   /* near-black canvas */
+--bg-alt:          #0f0f0f
+--surface:         #161616   /* terminal cell elevation */
+--surface-2:       #1f1f1f
+--text:            #d2d2d2   /* off-white, primary */
+--text-muted:      #8a8a8a
+--text-dim:        #5a5a5a
+--border:          #2a2a2a
+--border-strong:   #3a3a3a
+
+--accent:          #50fa7b   /* phosphor green — primary action + active state */
+--accent-hover:    #6fff95
+--accent-deep:     #2cc955
+
+/* terminal-palette echoes — used in syntax + diffs only */
+--cyan:            #8be9fd
+--purple:          #bd93f9
+--yellow:          #f1fa8c
+--orange:          #ffb86c
+--red:             #ff5555   /* error, deletion */
+--green-deep:      #5af78e   /* addition */
+--pink:            #ff79c6
+```
+
+Rule: green carries action, active cursor, and accepted state. The terminal-palette echoes (`--cyan`, `--purple`, etc.) appear inside diffs, syntax highlighting, and log streams only. Never as marketing accents. Never gradient between them.
+
+## 3. Typography Rules
+
+- **Everything:** `IBM Plex Mono`, fallback `JetBrains Mono`, `SF Mono`, `Menlo`, `Consolas`, `monospace`. Weight 400/500/700.
+- One typeface across chrome, body, code, headlines. Mixed weights carry hierarchy — never mixed faces.
+- **Numerals:** native to mono (always tabular).
+- Letter-spacing 0. Line-height 1.5 on body, 1.4 on code.
+
+Scale: 12 / 13 / 14 / 16 / 18 / 22 / 28 / 36 / 48.
+
+Headlines stay restrained — IBM Plex Mono at 36–48px reads as ASCII banner, not magazine display. Hero copy can lean on multi-line ASCII art for the brand moment.
+
+## 4. Component Stylings
+
+**Buttons**
+- Primary: green fill `--accent`, near-black text `--bg`, radius 4px, padding 8/14, weight 500. Hover: `--accent-hover`. No lift, no scale.
+- Secondary: transparent fill, 1px `--border-strong`, off-white text. Hover: 1px `--accent` border.
+- Tertiary / link: off-white text, green underline on hover.
+- Destructive: `--red` fill, near-black text, only on confirm modals.
+
+**Cards / blocks**
+- `--surface` fill, 1px `--border`, radius 4px. Padding 16. Header in 12px uppercase tracked +4%.
+- Code blocks: `--bg-alt` fill, 1px `--border`, no header chrome unless filename is shown in 12px muted mono.
+- Hover: 1px `--accent` border. No shadow, no lift.
+
+**Inputs / prompt**
+- `--bg-alt` fill, 1px `--border-strong`, radius 4px, padding 8/12.
+- Focus: 1px `--accent` border (no offset, no ring — terminal-honest).
+- Active prompt line: 1px `--accent` left border, blinking caret in `--accent`.
+
+**Nav**
+- Top nav: `--bg` fill, 1px bottom `--border`, mono links, green underline on active.
+- ASCII-style breadcrumb (`~/docs/getting-started`) for in-app navigation.
+
+**Diff + log views**
+- Additions in `--green-deep`, deletions in `--red`, both at 12% opacity background plus full-opacity text.
+- Line numbers in `--text-dim`, gutter in `--bg-alt`.
+- ANSI-color log lines preserved (`--cyan` for paths, `--purple` for keywords, `--yellow` for warnings).
+
+## 5. Layout Principles
+
+- 1024px max for marketing reading. Full-width app shell.
+- Single-column hero. Two-column max for spec / install steps.
+- 4px base. 4 / 8 / 12 / 16 / 24 / 32 / 48.
+- Density first. Generous vertical whitespace is anti-terminal — keep blocks tight.
+- Code is the hero. Show a real session transcript above the fold.
+
+## 6. Depth & Elevation
+
+Flat. Border + tonal shift only. No drop shadows. No glows. The entire elevation language is `bg → bg-alt → surface → surface-2`. Modals use `--surface-2` with a 1px `--accent` border instead of shadow.
+
+## 7. Do's and Don'ts
+
+**Do**
+- Use IBM Plex Mono across every surface — chrome, body, code.
+- Reserve green for action, active line, accepted state.
+- Show real session transcripts as the hero artifact (no stylized mockups).
+- Keep corners at 4px. Hard edges read as terminal cells.
+- Render ASCII banners for section breaks.
+
+**Don't**
+- Introduce a second typeface. Mono everywhere or nothing.
+- Soften corners past 6px.
+- Use light backgrounds. OpenCode is dark only.
+- Add gradient fills, glows, or scale-on-hover lifts.
+- Use the terminal-palette echoes (`--cyan`, `--purple`) outside of diff and log surfaces.
+
+## 8. Responsive Behavior
+
+- Single-column hero scales naturally. Mono body holds 14–16px on mobile.
+- Nav collapses to drawer at 768px; ASCII breadcrumb truncates left-side.
+- Code blocks become horizontally scrollable below 640px (no soft-wrap of code).
+- Diff views become unified (single column) instead of split below 768px.
+
+## 9. Agent Prompt Guide
+
+Bias: near-black `#080808` canvas with off-white `#d2d2d2` text, single phosphor-green `#50fa7b` accent for action and active state, IBM Plex Mono across every surface (chrome, body, code), 4px radii, terminal-palette echoes reserved for diffs and log streams only, real session transcripts as hero, ASCII breadcrumbs and section banners.
+
+Reject: light-mode pages, multi-typeface mixing (sans + mono), gradient fills, drop shadows, scale-on-hover lifts, decorative illustration in chrome, stock photography, marketing-pastel accents, the terminal-palette echoes leaking into chrome.


### PR DESCRIPTION
Wave 2 of brand DESIGN.md depth, slotted by aesthetic family per `AGENTS.md`. All 5 files follow the 9-section canonical structure with hex tokens under role names (no brand-name color vars), no emojis, no marketing fluff, and close with an Agent Prompt Guide containing explicit Bias and Reject clauses.

## Per-brand family + token highlights

### `data-dense/mongodb.md`
- **Family**: Data-Dense Pro — Atlas console is dashboard-first, marketing is light editorial with code-as-hero
- **Tokens**: deep slate `#001e2b` app shell, leaf `#00ed64` brand + primary CTA, `#00684a` deep forest variant for ink-on-light, Euclid Circular A + Source Code Pro stack, 8-color categorical chart palette in declared order, 32px dense table rows, 6px in-app radii / 8px marketing
- **Reference**: live `mongodb.com` (firecrawl branding extract)

### `cinematic/nvidia.md`
- **Family**: Cinematic Dark — black canvas, full-bleed video hero, oversized grotesque, single signature green CTA
- **Tokens**: `#000000` canvas, signature `#76b900` green (verified from live nvidia.com), `#10b1fb` cyan reserved for developer surfaces only (CUDA / RAPIDS), NVIDIA Sans / Helvetica Neue tight grotesque, 96–128px display headlines, 4px hard radii, mega-menu nav with 8px backdrop blur
- **Reference**: live `nvidia.com/en-us/` (firecrawl returned `primary: #76B900`)

### `cinematic/minimax.md`
- **Family**: Cinematic Dark — black + charcoal chrome with one neon-lime moment per viewport, looping demo media as hero
- **Tokens**: `#000000` canvas, `#181E25` charcoal `--surface` (verified from live minimax.io), `#c8ff00` neon-lime CTA per AGENTS.md README table convention, Outfit display + DM Sans body (verified Google Fonts stack from live site), 60px pill primary buttons alongside 12px-radius secondaries — the geometric collision is the brand
- **Reference**: live `minimax.io` (firecrawl branding extract)

### `playful/toss.md`
- **Family**: Playful Color — Korean fintech, friendly mood, mobile-first, two-step blue hierarchy
- **Tokens**: white `#ffffff` canvas, Toss Blue `#3182f6` primary + tinted-blue `#e8f3ff` secondary (the signature two-step), `#191f28` ink, Toss Product Sans + Noto Sans KR + Apple SD Gothic Neo fallback chain (verified from live site), 7px button radii / 12px card radii, mobile-first 480px content lane, 64px tap-target row heights, mint `#00c896` / coral `#f04452` for positive / decline state
- **Reference**: live `toss.im` (firecrawl branding extract)

### `terminal/opencode.md`
- **Family**: Terminal-Core — IBM Plex Mono everywhere, near-black canvas, single phosphor-green action, real session transcripts as hero
- **Tokens**: `#080808` canvas, `#d2d2d2` off-white text, `#50fa7b` phosphor-green action, terminal-palette echoes (`#8be9fd` cyan, `#bd93f9` purple, `#f1fa8c` yellow, `#ff5555` red, `#5af78e` green-deep) reserved for diff and log views only, IBM Plex Mono across chrome / body / code, 4px hard radii, no shadows, ASCII breadcrumbs and section banners
- **Reference**: live `opencode.ai` (WebFetch)

## README wiring

- `Shipped samples in this repo:` line under `## DESIGN.md by Aesthetic Family` updated to include all 5 new files
- Family tables: added MongoDB row to Data-Dense Pro, NVIDIA row to Cinematic Dark, Toss row to Playful Color
- OpenCode and Minimax rows were already present in their respective tables — left untouched

## Out of scope (per task)

Not touched: banner, hero, gallery, anti-slop, recipes, comparisons, community takes.