### PR TITLE
fix(mascot): arms stay attached to shoulders, hands visible, drop pen flicker

### DIFF
--- a/assets/mascot-dance.svg
+++ b/assets/mascot-dance.svg
@@ -79,28 +79,35 @@
       <rect x="62" y="62" width="6" height="6" fill="#0acf83"/>
     </g>
 
-    <!-- left arm (waves) -->
+    <!-- left arm (waves) — outer g pins shoulder, inner g rotates around (0,0) -->
     <g transform="translate(16, 48)">
-      <animateTransform attributeName="transform" type="rotate" values="0 0 0; -30 0 0; 0 0 0; 30 0 0; 0 0 0" dur="1.2s" repeatCount="indefinite" additive="replace"/>
-      <g shape-rendering="crispEdges">
-        <rect x="-4" y="0" width="8" height="24" class="ink"/>
-        <rect x="-4" y="24" width="8" height="4" class="cream"/>
+      <g>
+        <animateTransform attributeName="transform" type="rotate" values="0 0 0; -30 0 0; 0 0 0; 30 0 0; 0 0 0" dur="1.2s" repeatCount="indefinite"/>
+        <g shape-rendering="crispEdges">
+          <!-- sleeve -->
+          <rect x="-4" y="0" width="8" height="22" class="ink"/>
+          <!-- hand: 10x8 cream block, clearly readable -->
+          <rect x="-5" y="22" width="10" height="8" class="cream"/>
+          <rect x="-5" y="22" width="10" height="2" class="clay"/>
+        </g>
       </g>
     </g>
 
-    <!-- right arm with brush (paints air) -->
+    <!-- right arm with brush — same structure -->
     <g transform="translate(80, 48)">
-      <animateTransform attributeName="transform" type="rotate" values="0 0 0; 35 0 0; 0 0 0; -35 0 0; 0 0 0" dur="1.2s" repeatCount="indefinite" additive="replace"/>
-      <g shape-rendering="crispEdges">
-        <rect x="-4" y="0" width="8" height="24" class="ink"/>
-        <rect x="-4" y="24" width="8" height="4" class="cream"/>
-        <rect x="0" y="28" width="4" height="2" fill="#8a6a4a"/>
-        <rect x="0" y="30" width="4" height="6" class="accent"/>
-        <!-- paint splatter -->
-        <circle cx="2" cy="40" r="2" class="clay">
-          <animate attributeName="opacity" values="0;1;0" dur="1.2s" repeatCount="indefinite"/>
-          <animate attributeName="cy" values="40;50;60" dur="1.2s" repeatCount="indefinite"/>
-        </circle>
+      <g>
+        <animateTransform attributeName="transform" type="rotate" values="0 0 0; 35 0 0; 0 0 0; -35 0 0; 0 0 0" dur="1.2s" repeatCount="indefinite"/>
+        <g shape-rendering="crispEdges">
+          <!-- sleeve -->
+          <rect x="-4" y="0" width="8" height="22" class="ink"/>
+          <!-- hand: 10x8 cream block -->
+          <rect x="-5" y="22" width="10" height="8" class="cream"/>
+          <rect x="-5" y="22" width="10" height="2" class="clay"/>
+          <!-- brush handle (held by hand) -->
+          <rect x="-1" y="30" width="4" height="4" fill="#8a6a4a"/>
+          <!-- brush bristles -->
+          <rect x="-2" y="34" width="6" height="6" class="accent"/>
+        </g>
       </g>
     </g>
 


### PR DESCRIPTION
## Summary

Direct user feedback: \"what is that pen broken flicker and why it doesnt have hands?\" — looking at the dancing mascot in the README hero.

## Root causes

1. **Arms detached from shoulders mid-animation.** Each arm group used `<animateTransform type=\"rotate\" additive=\"replace\">`. The default behavior of \`additive=\"replace\"\` is to OVERWRITE the parent's static \`transform=\"translate(16,48)\"\` / \`translate(80,48)\` shoulder anchor on every keyframe — so during animation the arms snapped to (0,0) of the mascot group, floating away from the torso.

2. **Hands invisible.** The hand was a 4px cream sliver. At the 320x200 render scale used in the README hero, that's roughly 1-2 device pixels. Reads as nothing.

3. **\"Pen flicker.\"** A paint-splatter \`<circle>\` with \`opacity 0→1→0\` and \`cy 40→60\` falling animation. Combined with the detached arm + brush, it read as a broken pen blinking in midair.

## Fixes

- Wrapped each arm's rotate animation in an inner \`<g>\` so the outer translate stays applied (rotation now pivots around the shoulder, not the page origin).
- Enlarged hand to 10x8 cream block with a 2px clay cuff for clarity.
- Removed the paint-splatter circle entirely.
- Tightened brush position so it visually attaches to the hand (handle starts at hand-bottom, bristles below).

## Diff

\`assets/mascot-dance.svg\` only. Validated via \`xmllint --noout\`.